### PR TITLE
Scope created before callbacks

### DIFF
--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -98,6 +98,7 @@ namespace OZW {
 	void handleNotification(NotifInfo *notif) 
 	// ===================================================================
 	{
+		NanScope();
 		NodeInfo *node;
 				
 		Local < v8::Value > args[16];
@@ -322,6 +323,7 @@ namespace OZW {
 	void handleControllerCommand(NotifInfo *notif) 
 	// ===================================================================
 	{
+		NanScope();
 		Local < v8::Value > args[16];
 		args[0] = NanNew<String>("controller command");
 		args[1] = NanNew<Integer>(notif->state);


### PR DESCRIPTION
I ran into an error trying to use this module in io.js 2.5.0, getting the following message after trying to connect:

```
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
```

Adding NanScope() calls to the async callbacks seems to fix the problem.  I'm honestly not sure if this is the right way to go or not, but thought I'd pass along the change.