### PR TITLE
Osx compat

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,35 @@
 			"src/utils.cc",
 		],
 		"conditions": [
+			['OS=="mac"', {
+				"variables": {
+					"OZW_INC"         : "<!(pkg-config --cflags-only-I libopenzwave | sed s/-I//g)",
+					"OZW_GITVERSION"  : "<!(pkg-config --variable=gitversion libopenzwave)",
+					"OZW_ETC"         : "<!(pkg-config --variable=sysconfdir libopenzwave)",
+					"OZW_DOC"         : "<!(pkg-config --variable=docdir libopenzwave)"
+				},
+        		"defines": [
+					"OPENZWAVE_ETC=<(OZW_ETC)/config",
+					"OPENZWAVE_DOC=<!@(node -p -e \"'<(OZW_DOC)'.length ? '<(OZW_DOC)' : '/usr/local/share/doc/openzwave'\")",
+					"OPENZWAVE_SECURITY=<!@(find <(OZW_INC) -name ZWSecurity.h | wc -l)"
+        		],
+				"link_settings": {
+				    "libraries": [
+						"-L/usr/local/lib/", "-lopenzwave"
+					]
+				},
+                "include_dirs": [
+                    "<!(node -p -e \"require('path').dirname(require.resolve('nan'))\")",
+                    '/usr/local/include/openzwave/',
+                    '/usr/local/include/openzwave/value_classes/'
+                ],
+				'xcode_settings': {
+					'MACOSX_DEPLOYMENT_TARGET':'10.8',
+			        'OTHER_CFLAGS': [
+						'-Wno-ignored-qualifiers -Wno-write-strings -Wno-unknown-pragmas'
+			        ]
+			      }
+	        }],
 			["OS=='linux'", {
 				"variables": {
 					"PKG_CONFIG_PATH" : "<!(find /usr/local -type d ! -perm -g+r,u+r,o+r -prune -o -type d -name 'pkgconfig' -printf \"%p:\" | sed s/:$//g)",
@@ -42,7 +71,7 @@
 			['OS=="win"', {
 				"variables": {
 					"OZW_HOME": "<!(node lib/install-ozw.js --get-ozw-home)"
-				},						
+				},
 				"include_dirs": [
 					"<!(node -e \"require('nan')\")",
 					"<(OZW_HOME)/include",
@@ -51,7 +80,7 @@
 				"defines": [
 					"OPENZWAVE_ETC=<(OZW_HOME)/config",
 					"OPENZWAVE_SECURITY=1"
-				],				
+				],
 				'msvs_settings': {
 					'VCLinkerTool': {
 						'AdditionalDependencies': ['setupapi.lib', '<(OZW_HOME)/bin/OpenZWave.lib']

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,7 @@
                     '/usr/local/include/openzwave/value_classes/'
                 ],
 				'xcode_settings': {
-					'MACOSX_DEPLOYMENT_TARGET':'10.8',
+					'MACOSX_DEPLOYMENT_TARGET':'10.9',
 			        'OTHER_CFLAGS': [
 						'-Wno-ignored-qualifiers -Wno-write-strings -Wno-unknown-pragmas'
 			        ]

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -70,7 +70,7 @@ namespace OZW {
 		}
 
 		{
-			mutex::scoped_lock sl(zqueue_mutex);
+			mutexx::scoped_lock sl(zqueue_mutex);
 			zqueue.push(notif);
 		}
 		uv_async_send(&async);
@@ -92,7 +92,7 @@ namespace OZW {
 		notif->notification = _state;
 		notif->homeid       = 0; // use as guard value for legacy mode
 		{
-			mutex::scoped_lock sl(zqueue_mutex);
+			mutexx::scoped_lock sl(zqueue_mutex);
 			zqueue.push(notif);
 		}
 		uv_async_send(&async);
@@ -187,7 +187,7 @@ namespace OZW {
 				node->nodeid = notif->nodeid;
 				node->polled = false;
 				{
-					mutex::scoped_lock sl(znodes_mutex);
+					mutexx::scoped_lock sl(znodes_mutex);
 					znodes.push_back(node);
 				}
 				emitinfo[0] = Nan::New<String>("node added").ToLocalChecked();
@@ -232,7 +232,7 @@ namespace OZW {
 				Local<Object> valobj = zwaveValue2v8Value(value);
 
 				if ((node = get_node_info(notif->nodeid))) {
-					mutex::scoped_lock sl(znodes_mutex);
+					mutexx::scoped_lock sl(znodes_mutex);
 					node->values.push_back(value);
 				}
 
@@ -373,7 +373,7 @@ namespace OZW {
 	{
 		NotifInfo *notif;
 
-		mutex::scoped_lock sl(zqueue_mutex);
+		mutexx::scoped_lock sl(zqueue_mutex);
 
 		while (!zqueue.empty()) {
 			notif = zqueue.front();

--- a/src/openzwave-scenes.cc
+++ b/src/openzwave-scenes.cc
@@ -40,7 +40,7 @@ namespace OZW {
 			scene = new SceneInfo();
 			scene->sceneid = sceneid;
 			scene->label = label;
-			mutex::scoped_lock sl(zscenes_mutex);
+			mutexx::scoped_lock sl(zscenes_mutex);
 			zscenes.push_back(scene);
 		}
 
@@ -59,7 +59,7 @@ namespace OZW {
 
 		if ((scene = get_scene_info(sceneid))) {
 			OpenZWave::Manager::Get()->RemoveScene(sceneid);
-			mutex::scoped_lock sl(zscenes_mutex);
+			mutexx::scoped_lock sl(zscenes_mutex);
 			zscenes.remove(scene);
 		}
 	}
@@ -75,7 +75,7 @@ namespace OZW {
 
 		if (numscenes != zscenes.size()) {
 			{
-				mutex::scoped_lock sl(zscenes_mutex);
+				mutexx::scoped_lock sl(zscenes_mutex);
 				zscenes.clear();
 			}
 			uint8 *sceneids;
@@ -88,7 +88,7 @@ namespace OZW {
 				scene->sceneid = sceneids[i];
 
 				scene->label = OpenZWave::Manager::Get()->GetSceneLabel(sceneids[i]);
-				mutex::scoped_lock sl(zscenes_mutex);
+				mutexx::scoped_lock sl(zscenes_mutex);
 				zscenes.push_back(scene);
 			}
 		}
@@ -243,7 +243,7 @@ namespace OZW {
 			unsigned j = 0;
 
 			for (vit = values.begin(); vit != values.end(); ++vit) {
-				mutex::scoped_lock sl(zscenes_mutex);
+				mutexx::scoped_lock sl(zscenes_mutex);
 				scene->values.push_back(*vit);
 
 				v8values->Set(Nan::New<Integer>(j++), zwaveSceneValue2v8Value(sceneid, *vit));

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -30,20 +30,21 @@ namespace OZW {
 	Nan::Callback *emit_cb;
 
 	// Message passing queue between OpenZWave callback and v8 async handler.
-	mutex 		            zqueue_mutex;
+	mutexx 		            zqueue_mutex;
 	std::queue<NotifInfo *> zqueue;
 
 	// Node state.
-	mutex 		          znodes_mutex;
+	mutexx 		          znodes_mutex;
 	std::list<NodeInfo *> znodes;
 
-	mutex zscenes_mutex;
+	mutexx zscenes_mutex;
 	std::list<SceneInfo *> zscenes;
 
 	uint32      homeid;
 	CommandMap* ctrlCmdNames;
 
 	std::string ozw_userpath;
+
 	const std::string ozw_config_path  = stringify( OPENZWAVE_ETC );
 
 	// ===================================================================

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -65,6 +65,33 @@ private:
 };
 #endif
 
+#ifdef __APPLE__
+#include <unistd.h>
+#include <pthread.h>
+
+class mutexx {
+public:
+	mutexx()             { pthread_mutex_init(&_mutex, NULL); }
+	~mutexx()            { pthread_mutex_destroy(&_mutex); }
+	inline void lock()  { pthread_mutex_lock(&_mutex); }
+	inline void unlock(){ pthread_mutex_unlock(&_mutex); }
+
+	class scoped_lock
+	{
+	public:
+		inline explicit scoped_lock(mutexx & sp) : _sl(sp)  { _sl.lock(); }
+		inline ~scoped_lock()                              { _sl.unlock(); }
+	private:
+		scoped_lock(scoped_lock const &);
+		scoped_lock & operator=(scoped_lock const &);
+		mutexx&  _sl;
+	};
+
+private:
+	pthread_mutex_t _mutex;
+};
+#endif
+
 #ifdef linux
 #include <unistd.h>
 #include <pthread.h>

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -48,23 +48,23 @@
 #define stringify_literal( x ) # x
 
 #ifdef WIN32
-class mutex
+class mutexx
 {
 public:
-	mutex()              { InitializeCriticalSection(&_criticalSection); }
-	~mutex()             { DeleteCriticalSection(&_criticalSection); }
+	mutexx()              { InitializeCriticalSection(&_criticalSection); }
+	~mutexx()             { DeleteCriticalSection(&_criticalSection); }
 	inline void lock()   { EnterCriticalSection(&_criticalSection); }
 	inline void unlock() { LeaveCriticalSection(&_criticalSection); }
 
 	class scoped_lock
 	{
 	public:
-		inline explicit scoped_lock(mutex & sp) : _sl(sp) { _sl.lock(); }
+		inline explicit scoped_lock(mutexx & sp) : _sl(sp) { _sl.lock(); }
 		inline ~scoped_lock()                             { _sl.unlock(); }
 	private:
 		scoped_lock(scoped_lock const &);
 		scoped_lock & operator=(scoped_lock const &);
-		mutex& _sl;
+		mutexx& _sl;
 	};
 
 private:

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -21,9 +21,16 @@
 #include <iostream>
 #include <list>
 #include <queue>
+
 #ifdef _WIN32
     #include <unordered_map>
-#else
+#endif
+
+#ifdef __APPLE__
+    #include <unordered_map>
+#endif
+
+#ifdef linux
     #include <tr1/unordered_map>
 #endif
 
@@ -306,7 +313,12 @@ namespace OZW {
 	//
 
 	// map of controller command names to enum values
-	typedef ::std::tr1::unordered_map <std::string, OpenZWave::Driver::ControllerCommand> CommandMap;
+  #ifdef __APPLE__
+    typedef ::std::unordered_map <std::string, OpenZWave::Driver::ControllerCommand> CommandMap;
+  #else
+    typedef ::std::tr1::unordered_map <std::string, OpenZWave::Driver::ControllerCommand> CommandMap;
+  #endif
+
 	extern CommandMap* ctrlCmdNames;
 
 }

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -96,7 +96,7 @@ private:
 #include <unistd.h>
 #include <pthread.h>
 
-class mutex
+class mutexx
 {
 public:
 	mutex()             { pthread_mutex_init(&_mutex, NULL); }
@@ -107,12 +107,12 @@ public:
 	class scoped_lock
 	{
 	public:
-		inline explicit scoped_lock(mutex & sp) : _sl(sp)  { _sl.lock(); }
+		inline explicit scoped_lock(mutexx & sp) : _sl(sp)  { _sl.lock(); }
 		inline ~scoped_lock()                              { _sl.unlock(); }
 	private:
 		scoped_lock(scoped_lock const &);
 		scoped_lock & operator=(scoped_lock const &);
-		mutex&  _sl;
+		mutexx&  _sl;
 	};
 
 private:
@@ -267,16 +267,16 @@ namespace OZW {
 	/*
 	* Message passing queue between OpenZWave callback and v8 async handler.
 	*/
-	extern mutex zqueue_mutex;
+	extern mutexx zqueue_mutex;
 	extern std::queue<NotifInfo *> zqueue;
 
 	/*
 	* Node state.
 	*/
-	extern mutex znodes_mutex;
+	extern mutexx znodes_mutex;
 	extern std::list<NodeInfo *> znodes;
 
-	extern mutex zscenes_mutex;
+	extern mutexx zscenes_mutex;
 	extern std::list<SceneInfo *> zscenes;
 
 	// our ZWave Home ID

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
  */
 
 var OpenZWave = require('./lib/openzwave-shared.js');
+var os = require('os');
 
 var zwave = new OpenZWave({
 	ConsoleOutput: false,
@@ -10,7 +11,7 @@ var zwave = new OpenZWave({
 	SaveConfiguration: false,
 	DriverMaxAttempts: 3,
 	PollInterval: 500,
-	SuppressValueRefresh: true,
+	SuppressValueRefresh: true
 });
 var nodes = [];
 
@@ -131,7 +132,11 @@ zwave.on('scan complete', function() {
 	console.log('scan complete, hit ^C to finish.');
 });
 
-zwave.connect('/dev/ttyUSB0');
+if(os.platform() == "darwin") {
+	zwave.connect('/dev/cu.usbmodem1411');
+} else {
+	zwave.connect('/dev/ttyUSB0');
+}
 
 process.on('SIGINT', function() {
 	console.log('disconnecting...');

--- a/test2.js
+++ b/test2.js
@@ -1,4 +1,6 @@
 var ZWave = require('./lib/openzwave-shared.js');
+var os = require('os');
+
 var zwave = new ZWave({
 	ConsoleOutput: false
 });
@@ -122,7 +124,12 @@ zwave.on('controller command', function(n,rv,st) {
     console.log('controller commmand feedback: node==%d, retval=%d, state=%d',n,rv,st);
 });
 
-zwave.connect('/dev/ttyUSB0');
+if(os.platform() == "darwin") {
+	zwave.connect('/dev/cu.usbmodem1411');
+} else {
+	zwave.connect('/dev/ttyUSB0');
+}
+
 
 process.on('SIGINT', function() {
     console.log('disconnecting...');


### PR DESCRIPTION
This allows the module to be compiled on osx (10.8 and above).

The biggest changes are handling platform specific `unordered_map` and renaming `mutex` to `mutexx` to avoid a naming conflict in the stdlib on osx. I apologize if I did something terrible, this is really my first spelunking into c++. If anyone with more experience with c++ wants to make a few changes (or suggestions), feel free.

The test files work with these changes on el capitan. 