### PR TITLE
Add support for raw value types

### DIFF
--- a/src/openzwave-values.cc
+++ b/src/openzwave-values.cc
@@ -88,6 +88,19 @@ namespace OZW {
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Raw: {
+					checkType(info[validx]->IsArray());
+					Local<Array> val = Local<Array>::Cast(info[validx]);
+					uint8 len = val->Length();
+					uint8 *valArr = new uint8[len];
+
+					for (uint8 i = 0; i < len; i++) {
+						Local<Object> idx = Local<Object>::Cast(val->Get(i));
+						if (!idx->IsNumber())
+							Nan::ThrowTypeError("Raw value array contains a non-integer");
+						valArr[i] = (uint8)idx->ToInteger()->Value();
+					}
+					OpenZWave::Manager::Get()->SetValue(*vit, valArr, len);
+					delete [] valArr;
 					break;
 				}
 			}

--- a/src/openzwave-values.cc
+++ b/src/openzwave-values.cc
@@ -88,19 +88,10 @@ namespace OZW {
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Raw: {
-					checkType(info[validx]->IsArray());
-					Local<Array> val = Local<Array>::Cast(info[validx]);
-					uint8 len = val->Length();
-					uint8 *valArr = new uint8[len];
-
-					for (uint8 i = 0; i < len; i++) {
-						Local<Object> idx = Local<Object>::Cast(val->Get(i));
-						if (!idx->IsNumber())
-							Nan::ThrowTypeError("Raw value array contains a non-integer");
-						valArr[i] = (uint8)idx->ToInteger()->Value();
-					}
-					OpenZWave::Manager::Get()->SetValue(*vit, valArr, len);
-					delete [] valArr;
+					checkType(Buffer::HasInstance(info[validx]));
+					uint8 *val = (uint8*)Buffer::Data(info[validx]);
+					uint8 len  = Buffer::Length(info[validx]);
+					OpenZWave::Manager::Get()->SetValue(*vit, val, len);
 					break;
 				}
 			}

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -155,6 +155,20 @@ namespace OZW {
 				break;
 			}
 			case OpenZWave::ValueID::ValueType_Raw: {
+				uint8 *val, len;
+				OpenZWave::Manager::Get()->GetValueAsRaw(value, &val, &len);
+
+				// Copy raw values into array.
+				Local<Array> rawval = Nan::New<Array>(len);
+				for (int i = 0; i < len; i++) {
+					rawval->Set(Nan::New<Integer>(i), Nan::New<Integer>(val[i]));
+				}
+				delete [] val;
+
+				Nan::Set(valobj,
+					Nan::New<String>("value").ToLocalChecked(),
+					rawval
+				);
 				break;
 			}
 			default: {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -157,18 +157,11 @@ namespace OZW {
 			case OpenZWave::ValueID::ValueType_Raw: {
 				uint8 *val, len;
 				OpenZWave::Manager::Get()->GetValueAsRaw(value, &val, &len);
-
-				// Copy raw values into array.
-				Local<Array> rawval = Nan::New<Array>(len);
-				for (int i = 0; i < len; i++) {
-					rawval->Set(Nan::New<Integer>(i), Nan::New<Integer>(val[i]));
-				}
-				delete [] val;
-
 				Nan::Set(valobj,
 					Nan::New<String>("value").ToLocalChecked(),
-					rawval
+					Nan::CopyBuffer((char *)val, len).ToLocalChecked()
 				);
+				delete [] val;
 				break;
 			}
 			default: {


### PR DESCRIPTION
This PR adds support for setting/getting raw value types, as arise in (for example) the usercode command class values. These are translated to V8 buffer objects since this seems to be the best container in terms of storing byte messages.