### PR TITLE
FIX: nodeid should be node_id

### DIFF
--- a/README-example.md
+++ b/README-example.md
@@ -1,7 +1,7 @@
 ## Example
 
 The test program below connects to a Z-Wave network, scans for all nodes and
-values, and prints out information about the network.  
+values, and prints out information about the network.
 
 **When the network has become ready**, the library will call 'scan complete'
 and the script will then 1) issue a `setValue` command to set a dimmer (node 5)
@@ -128,11 +128,11 @@ zwave.on('scan complete', function() {
     console.log('====> scan complete, hit ^C to finish.');
     // set dimmer node 5 to 50%
     //zwave.setValue(5,38,1,0,50);
-    zwave.setValue( {nodeid:5, class_id: 38, instance:1, index:0}, 50);
+    zwave.setValue( {node_id:5, class_id: 38, instance:1, index:0}, 50);
     // Add a new device to the ZWave controller
     if (zwave.hasOwnProperty('beginControllerCommand')) {
       // using legacy mode (OpenZWave version < 1.3) - no security
-      zwave.beginControllerCommand('AddDevice', true);      
+      zwave.beginControllerCommand('AddDevice', true);
     } else {
       // using new security API
       // set this to 'true' for secure devices eg. door locks

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Whenever you have OpenZWave installed in your machine, then all you need to do i
 $ npm install openzwave-shared
 ```
 
+**Notice:** If you receieve the error `cannot find -lopenzwave` on a 64-bit Linux system, `libopenzwave.so` was likely compiled into `/usr/local/lib64`. Run the terminal command `ld -lopenzwave --verbose` for a list of search locations used. You can workaround this by providing a symlink to one of the listed locations such as `/usr/local/lib`. Run `sudo ln -s /usr/local/lib64/libopenzwave.so /usr/local/lib/libopenzwave.so` creates symlink so that the file appears to be in the location that `ld` looks in. Now `npm install` should work.
+
 ## Development documentation
 
 - [Basic API usage](../master/README-api.md)

--- a/test2.js
+++ b/test2.js
@@ -118,7 +118,7 @@ zwave.on('scan complete', function() {
     console.log('====> scan complete, hit ^C to finish.');
     // set dimmer node 5 to 50%
     zwave.setValue(5,38,1,0,50);
-		//zwave.setValue({nodeid:5,	class_id: 38,	instance:1,	index:0}, 50 );
+	//zwave.setValue({node_id:5,	class_id: 38,	instance:1,	index:0}, 50 );
 });
 
 zwave.on('controller command', function(n,rv,st,msg) {


### PR DESCRIPTION
`README-example.md` and commented setValue() call in `test2.js` still use nodeid. They should be using node_id when using an object key for setValue().