### PR TITLE
Moved options into class for persistence of connection and disconnect.

### DIFF
--- a/src/openzwave-driver.cc
+++ b/src/openzwave-driver.cc
@@ -39,6 +39,12 @@ namespace OZW {
 
 		emit_cb = new Nan::Callback(callbackHandle);
 
+		OZW* self = ObjectWrap::Unwrap<OZW>(info.This());
+
+		// scan for OpenZWave options.xml in the nodeJS module's '/config' subdirectory
+		OpenZWave::Options::Create(self->config_path, self->userpath, self->option_overrides);
+		OpenZWave::Options::Get()->Lock();
+
 		OpenZWave::Manager::Create();
 		OpenZWave::Manager* mgr = OpenZWave::Manager::Get();
     mgr->AddWatcher(ozw_watcher_callback, NULL);

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -234,9 +234,11 @@ namespace OZW {
 			std::cout << "\tOption Overrides :" << option_overrides << "\n";
 		}
 
-		// scan for OpenZWave options.xml in the nodeJS module's '/config' subdirectory
-		OpenZWave::Options::Create(ozw_config_path, ozw_userpath, option_overrides);
-		OpenZWave::Options::Get()->Lock();
+		// Store configuration data for connect.
+		self->config_path = ozw_config_path;
+		self->userpath = ozw_userpath;
+		self->option_overrides = option_overrides;
+
 		//
 		info.GetReturnValue().Set(info.This());
 	}

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -163,6 +163,11 @@ namespace OZW {
 		static NAN_METHOD(RemoveSceneValue);
 		static NAN_METHOD(SceneGetValues);
 		static NAN_METHOD(ActivateScene);
+
+    // Passing configuration around
+    std::string userpath;
+    std::string option_overrides;
+    std::string config_path;
 	};
 
 	// our ZWave Home ID


### PR DESCRIPTION
Moved option creation logic into connect because otherwise options are destroyed on disconnect and never recreated. This fixes a bug that if you disconnect and then reconnect, options are not locked and you are unable to do so.