### PR TITLE
ignore winRT sources when building open zwave

### DIFF
--- a/lib/install-ozw.js
+++ b/lib/install-ozw.js
@@ -55,7 +55,8 @@ var ozwGyp = {
             "cpp/hidapi/linux/hid.c",
           ], 
           "sources/": [
-            ['exclude', 'cpp/src/platform/windows/']            
+            ['exclude', 'cpp/src/platform/windows/'],
+            ['exclude', 'cpp/src/platform/winRT/']
           ]
         }],
         ['OS=="mac"', {
@@ -64,7 +65,8 @@ var ozwGyp = {
             "cpp/hidapi/mac/hid.c",
           ], 
           "sources/": [
-            ['exclude', 'cpp/src/platform/windows/']            
+            ['exclude', 'cpp/src/platform/windows/'],
+            ['exclude', 'cpp/src/platform/winRT/']
           ],
           "defines": [
             "DARWIN"
@@ -77,7 +79,8 @@ var ozwGyp = {
             "cpp/hidapi/windows/hid.cpp",
           ], 
           "sources/": [
-            ['exclude', 'cpp/src/platform/unix/']            
+            ['exclude', 'cpp/src/platform/unix/'],
+            ['exclude', 'cpp/src/platform/winRT/']
           ]         
         }],
       ]


### PR DESCRIPTION
When installing on Windows, the open-zwave package is installed and built. The existing script fails because open-zwave added a winRT folder, and this needs to be ignored.