### PR TITLE
Fix linux build when libopenzwave is in /usr/local/lib

### DIFF
--- a/lib/ozwpaths.js
+++ b/lib/ozwpaths.js
@@ -66,7 +66,11 @@ function getConfigItem(item) {
       var loc = configs[item].locations[i];
       var cmd = util.format(cmdfmt, loc, fp);
       try {
-        return path.dirname(cp.execSync(cmd).toString().split('\n')[0]);
+        var dir = cp.execSync(cmd).toString().split('\n')[0];
+        if (!dir) {
+          continue;
+	}
+        return path.dirname(dir)
       } catch (e) {
         // console.log('not found in %s', loc);
       }


### PR DESCRIPTION
With openzwave installed from sources, I was unable to install this node module. The attached patch appears to fix the issue.