### PR TITLE
Fix deprecatione error that caused 'node-gyp rebuild' to fail on Windows

### DIFF
--- a/lib/install-ozw.js
+++ b/lib/install-ozw.js
@@ -8,7 +8,7 @@ var path = require('path');
 var request, unzip, gyp, wrench; //these are dynamically required later on
 
 var originalPath = process.cwd();
-var tempPath = path.resolve(require('os').tmpDir() + '/ozwinstall-' + Math.random().toString(36).substring(7));
+var tempPath = path.resolve(require('os').tmpdir() + '/ozwinstall-' + Math.random().toString(36).substring(7));
 var installPath =  path.resolve(process.env.HOMEPATH + '/AppData/Local/OpenZWave/');
 var ozwSourceUrl = "https://github.com/OpenZWave/open-zwave/archive/master.zip";
 var gypOptions = [];


### PR DESCRIPTION
I wasn't able to use "npm install" with Node 7.7.2 because the deprecation warn caused the lib/install-ozw.js script to exit incorrectly, causing node-gyp to fail.