### PR TITLE
Properly inherits from EventEmitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cproject
 .project
+.idea
 *.diff
 *.swo
 *.swp

--- a/lib/openzwave-shared.js
+++ b/lib/openzwave-shared.js
@@ -22,27 +22,9 @@ var debugAddon     = __dirname + '/../build/Debug/openzwave_shared.node';
 var releaseAddon   = __dirname + '/../build/Release/openzwave_shared.node';
 var addonFileName  = ((fs.existsSync(debugAddon)) ? debugAddon : releaseAddon);
 
- console.log("initialising OpenZWave addon ("+addonFileName+")");
+console.log("initialising OpenZWave addon ("+addonFileName+")");
 var addonModule = require(addonFileName);
 
-/*
- * we need a proxy EventEmitter instance because apparently there's
- * no (easy?) way to inherit an EventEmitter (JS code) from C++
- **/
-var ee = new EventEmitter();
-
-addonModule.Emitter.prototype.addListener = function(evt, callback) {
-	ee.addListener(evt, callback);
-}
-addonModule.Emitter.prototype.on = addonModule.Emitter.prototype.addListener;
-addonModule.Emitter.prototype.emit = function(evt, arg1, arg2, arg3, arg4) {
-	ee.emit(evt, arg1, arg2, arg3, arg4);
-}
-addonModule.Emitter.prototype.removeListener = function(evt, callback) {
-	ee.removeListener(evt, callback);
-}
-addonModule.Emitter.prototype.removeAllListeners = function(evt) {
-	ee.removeAllListeners(evt);
-}
+Object.assign(addonModule.Emitter.prototype, EventEmitter.prototype);
 
 module.exports = addonModule.Emitter;


### PR DESCRIPTION
Instead of creating an instance of an EventEmitter, and creating wrapper functions, we use Object.assign to inherit the while prototype.

This also has the added benefit of allowing chaining listener attachements.
```javascript
zwave
  .on('node added', eventHandle)
  .on('value changed', someOtherEventHandle);
```

This is because the prototype methods on EventEmitter returns 'this'.
But the wrapper functions did not.