### PR TITLE
Properly inherits from EventEmitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cproject
 .project
+.idea
 *.diff
 *.swo
 *.swp

--- a/lib/openzwave-shared.js
+++ b/lib/openzwave-shared.js
@@ -22,27 +22,40 @@ var debugAddon     = __dirname + '/../build/Debug/openzwave_shared.node';
 var releaseAddon   = __dirname + '/../build/Release/openzwave_shared.node';
 var addonFileName  = ((fs.existsSync(debugAddon)) ? debugAddon : releaseAddon);
 
- console.log("initialising OpenZWave addon ("+addonFileName+")");
+console.log("initialising OpenZWave addon ("+addonFileName+")");
 var addonModule = require(addonFileName);
 
 /*
- * we need a proxy EventEmitter instance because apparently there's
- * no (easy?) way to inherit an EventEmitter (JS code) from C++
- **/
-var ee = new EventEmitter();
+ Inheriting prototype EventEmitter
+ We would use Object.assign, but that isn't supported in node 0.12.
+ */
+addonModule.Emitter.prototype.addListener = EventEmitter.prototype.addListener;
+addonModule.Emitter.prototype.on = EventEmitter.prototype.on;
+addonModule.Emitter.prototype.once = EventEmitter.prototype.once;
+addonModule.Emitter.prototype.removeListener = EventEmitter.prototype.removeListener;
+addonModule.Emitter.prototype.removeAllListeners = EventEmitter.prototype.removeAllListeners;
+addonModule.Emitter.prototype.setMaxListeners = EventEmitter.prototype.setMaxListeners;
+addonModule.Emitter.prototype.listeners = EventEmitter.prototype.listeners;
+addonModule.Emitter.prototype.emit = EventEmitter.prototype.emit;
 
-addonModule.Emitter.prototype.addListener = function(evt, callback) {
-	ee.addListener(evt, callback);
+/*
+ Inheriting these, only if they exist on EventEmitter.
+ If we didn't, and added them either way, we would pollute the prototype with undefined keys.
+ */
+if (EventEmitter.prototype.getMaxListeners) {
+	addonModule.Emitter.prototype.getMaxListeners = EventEmitter.prototype.getMaxListeners;
 }
-addonModule.Emitter.prototype.on = addonModule.Emitter.prototype.addListener;
-addonModule.Emitter.prototype.emit = function(evt, arg1, arg2, arg3, arg4) {
-	ee.emit(evt, arg1, arg2, arg3, arg4);
+if (EventEmitter.prototype.prependListener) {
+	addonModule.Emitter.prototype.prependListener = EventEmitter.prototype.prependListener;
 }
-addonModule.Emitter.prototype.removeListener = function(evt, callback) {
-	ee.removeListener(evt, callback);
+if (EventEmitter.prototype.prependOnceListener) {
+	addonModule.Emitter.prototype.prependOnceListener = EventEmitter.prototype.prependOnceListener;
 }
-addonModule.Emitter.prototype.removeAllListeners = function(evt) {
-	ee.removeAllListeners(evt);
+if (EventEmitter.prototype.listenerCount) {
+	addonModule.Emitter.prototype.listenerCount = EventEmitter.prototype.listenerCount;
+}
+if (EventEmitter.prototype.eventNames) {
+	addonModule.Emitter.prototype.eventNames = EventEmitter.prototype.eventNames;
 }
 
 module.exports = addonModule.Emitter;


### PR DESCRIPTION
Instead of creating an instance of an EventEmitter, and creating wrapper functions, we copy directly from the prototype.

This has several benefits over how it was before.
For instance, chaining of listener attachments is now allowd.
```
zwave
  .on('node added', eventHandle)
  .on('value changed', someOtherEventHandle);
```
This is because the prototype methods on EventEmitter returns 'this'.
But the wrapper functions did not.