### PR TITLE
Fix for skipping the rest of a multi instance node

### DIFF
--- a/src/openzwave-polling.cc
+++ b/src/openzwave-polling.cc
@@ -74,7 +74,6 @@ namespace OZW {
 			for (vit = node->values.begin(); vit != node->values.end(); ++vit) {
 				if ((*vit).GetCommandClassId() == comclass) {
 					OpenZWave::Manager::Get()->EnablePoll((*vit), intensity);
-					break;
 				}
 			}
 		}
@@ -95,7 +94,6 @@ namespace OZW {
 			for (vit = node->values.begin(); vit != node->values.end(); ++vit) {
 				if ((*vit).GetCommandClassId() == comclass) {
 					OpenZWave::Manager::Get()->DisablePoll((*vit));
-					break;
 				}
 			}
 		}


### PR DESCRIPTION
When a node (GreenWave PowerNode 6 port, in my case) has multiple instances, all of the instance's ValueIDs need to be Enabled or Disabled for polling. The break prevented that.