### PR TITLE
Enable chaining on proxy EventEmitter method calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 zwcfg*
 zwscene.xml
 node_modules
+.idea

--- a/lib/openzwave-shared.js
+++ b/lib/openzwave-shared.js
@@ -33,16 +33,19 @@ var ee = new EventEmitter();
 
 addonModule.Emitter.prototype.addListener = function(evt, callback) {
 	ee.addListener(evt, callback);
+	return this;
 }
 addonModule.Emitter.prototype.on = addonModule.Emitter.prototype.addListener;
 addonModule.Emitter.prototype.emit = function(evt, arg1, arg2, arg3, arg4) {
-	ee.emit(evt, arg1, arg2, arg3, arg4);
+	return ee.emit(evt, arg1, arg2, arg3, arg4);
 }
 addonModule.Emitter.prototype.removeListener = function(evt, callback) {
 	ee.removeListener(evt, callback);
+	return this;
 }
 addonModule.Emitter.prototype.removeAllListeners = function(evt) {
 	ee.removeAllListeners(evt);
+	return this;
 }
 
 module.exports = addonModule.Emitter;


### PR DESCRIPTION
...addonModule.Emitter proxy methods should return `this` (except `emit` which needs to return its result).  