### PR TITLE
Add support for `once`

### DIFF
--- a/lib/openzwave-shared.js
+++ b/lib/openzwave-shared.js
@@ -35,6 +35,10 @@ addonModule.Emitter.prototype.addListener = function(evt, callback) {
 	ee.addListener(evt, callback);
 	return this;
 }
+addonModule.Emitter.prototype.once = function(evt, callback) {
+	ee.once(evt, callback);
+	return this;
+}
 addonModule.Emitter.prototype.on = addonModule.Emitter.prototype.addListener;
 addonModule.Emitter.prototype.emit = function(evt, arg1, arg2, arg3, arg4) {
 	return ee.emit(evt, arg1, arg2, arg3, arg4);


### PR DESCRIPTION
Tried to inherit all of `EventEmitter`'s functions, but that was harder than I thought and I couldn't get it to work quickly.