### PR TITLE
Only pass on the given arguments

### DIFF
--- a/lib/openzwave-shared.js
+++ b/lib/openzwave-shared.js
@@ -36,8 +36,8 @@ addonModule.Emitter.prototype.addListener = function(evt, callback) {
 	return this;
 }
 addonModule.Emitter.prototype.on = addonModule.Emitter.prototype.addListener;
-addonModule.Emitter.prototype.emit = function(evt, arg1, arg2, arg3, arg4) {
-	return ee.emit(evt, arg1, arg2, arg3, arg4);
+addonModule.Emitter.prototype.emit = function() {
+	return ee.emit.apply(ee, arguments);
 }
 addonModule.Emitter.prototype.removeListener = function(evt, callback) {
 	ee.removeListener(evt, callback);


### PR DESCRIPTION
Consider the following example:
```
zwave.on("node added", function() {
  console.log("Node Added:", arguments);
});
```

Before this PR the callback would receive `undefined` arguments as there was a fixed argument list.

Previous output:
```
Node Added: { '0': 1, '1': undefined, '2': undefined, '3': undefined }
Node Added: { '0': 2, '1': undefined, '2': undefined, '3': undefined }
Node Added: { '0': 4, '1': undefined, '2': undefined, '3': undefined }
Node Added: { '0': 8, '1': undefined, '2': undefined, '3': undefined }
Node Added: { '0': 19, '1': undefined, '2': undefined, '3': undefined }
```

After this PR the output will be the following as it only passes the given arguments to the callback:

New output:
```
Node Added: { '0': 1 }
Node Added: { '0': 2 }
Node Added: { '0': 4 }
Node Added: { '0': 8 }
Node Added: { '0': 19 }
```