### PR TITLE
Make sure only one instance is started

### DIFF
--- a/lib/openzwave-shared.js
+++ b/lib/openzwave-shared.js
@@ -48,4 +48,8 @@ addonModule.Emitter.prototype.removeAllListeners = function(evt) {
 	return this;
 }
 
-module.exports = addonModule.Emitter;
+var instance;
+module.exports = function(options) {
+  if (!instance) instance = new addonModule.Emitter(options);
+  return instance;
+}


### PR DESCRIPTION
This reflects the OpenZWave's Manager singleton and makes it more clear that only one node object has to be initiated.

```
var OpenZWave = require("./lib/openzwave-shared.js");

const zwave = new OpenZWave({ ConsoleOutput: false });
const zwave1 = new OpenZWave({ ConsoleOutput: false });

console.log(zwave === zwave1); 
# => true
```

Even though this API is fully backwards compatible I would like to propose a change in the documentation to address the case that only 1 OpenZWave stack can be started per application and when this PR is merged, the following even simpler API also works:

```
var zwave = require("./lib/openzwave-shared.js")({ ConsoleOutput: false });

zwave.on("...")
```

Happy to add another commit making this change in the documentation.

