### PR TITLE
Pass object including the home id as callback arg

### DIFF
--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -150,7 +150,11 @@ void handleNotification(NotifInfo *notif)
 {
   Nan::HandleScope scope;
   Local<v8::Value> emitinfo[16];
+  Local<Object> emitobj = Nan::New<Object>();
   Local<Object> cbinfo = Nan::New<Object>();
+
+  AddIntegerProp(emitobj, homeid, notif->homeid);
+
 	//
   NodeInfo *node;
   //
@@ -239,8 +243,9 @@ void handleNotification(NotifInfo *notif)
       mutex::scoped_lock sl(znodes_mutex);
       znodes[notif->nodeid] = node;
     }
+    AddIntegerProp(emitobj, nodeid, notif->nodeid);
     emitinfo[0] = Nan::New<String>("node added").ToLocalChecked();
-    emitinfo[1] = Nan::New<Integer>(notif->nodeid);
+    emitinfo[1] = emitobj;
     emit_cb->Call(2, emitinfo);
     break;
   }


### PR DESCRIPTION
**❗ NOT FINISHED, JUST A PROPOSAL**

I would like to add support for multiple drivers in node-openzwave because the underlaying OpenZWave stack supports this easily. The main reason we want this is that we want to bridge multiple ZWave networks and we can work around the limit of [232 ZWave devices](http://www.z-wave.com/faq) per network. As you can see from my previous PRs, I'm working my way up to this change.

The remaining problem is that we'll need the current `homeid` in every event so we can distinguish the different ZWave networks. We can do this easily by just adding the `homeid` to the end of the argument list for each event. This doesn't break the current API, but it also doesn't feel right.

My proposal is to break the current API now in a constructive manner to allow future expansions more easily. So instead of just adding another argument, pass every event handler an object including all arguments. And now we can also apply the destructuring assignment syntax to only get the arguments we're interested in.

```
{
  homeid: 123123,
  nodeid: 1,
  ...
}
```


The following code example is functional within this PR:

```
var OpenZWave = require("./lib/openzwave-shared.js");

const zwave = new OpenZWave({ ConsoleOutput: false });

// let's start two zwave usb controllers
zwave.connect("/dev/cu.usbmodem1411");
zwave.connect("/dev/cu.usbmodem1451");

// new syntax
zwave.on("node added", ({homeid, nodeid}) => {
  console.log(`Node Added '${nodeid}' in home '0x${homeid.toString(16)}'`);
});

// or the old
zwave.on("node added", function(event) {
  console.log("Node Added '" + event.nodeid + "' in home '0x" + event.homeid.toString(16) + "'");
});
```

Let me know what you think! 😎