### PR TITLE
Inherit all EventEmitter's functions

### DIFF
--- a/lib/openzwave-shared.js
+++ b/lib/openzwave-shared.js
@@ -21,31 +21,10 @@ var EventEmitter = require('events').EventEmitter;
 var debugAddon     = __dirname + '/../build/Debug/openzwave_shared.node';
 var releaseAddon   = __dirname + '/../build/Release/openzwave_shared.node';
 var addonFileName  = ((fs.existsSync(debugAddon)) ? debugAddon : releaseAddon);
+var addonModule    = require(addonFileName);
 
- console.log("initialising OpenZWave addon ("+addonFileName+")");
-var addonModule = require(addonFileName);
-
-/*
- * we need a proxy EventEmitter instance because apparently there's
- * no (easy?) way to inherit an EventEmitter (JS code) from C++
- **/
-var ee = new EventEmitter();
-
-addonModule.Emitter.prototype.addListener = function(evt, callback) {
-	ee.addListener(evt, callback);
-	return this;
-}
-addonModule.Emitter.prototype.on = addonModule.Emitter.prototype.addListener;
-addonModule.Emitter.prototype.emit = function(evt, arg1, arg2, arg3, arg4) {
-	return ee.emit(evt, arg1, arg2, arg3, arg4);
-}
-addonModule.Emitter.prototype.removeListener = function(evt, callback) {
-	ee.removeListener(evt, callback);
-	return this;
-}
-addonModule.Emitter.prototype.removeAllListeners = function(evt) {
-	ee.removeAllListeners(evt);
-	return this;
+for (var k in EventEmitter.prototype) {
+  addonModule.Emitter.prototype[k] = EventEmitter.prototype[k];
 }
 
 module.exports = addonModule.Emitter;

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -28,6 +28,7 @@ uv_async_t async;
 
 //
 Nan::Callback *emit_cb;
+Nan::CopyablePersistentTraits<v8::Object>::CopyablePersistent ctx_obj;
 
 // Message passing queue between OpenZWave callback and v8 async handler.
 mutex zqueue_mutex;
@@ -136,7 +137,7 @@ void handleControllerCommand(NotifInfo *notif)
   info[2] = Nan::New<Integer>(notif->event);        // Driver::ControllerCommand
   info[3] = Nan::New<Integer>(notif->notification); // Driver::ControllerCommand
   info[4] = Nan::New<String>(notif->help.c_str()).ToLocalChecked();
-  emit_cb->Call(5, info);
+  emit_cb->Call(Nan::New(ctx_obj), 5, info);
 }
 // ##### END OF LEGACY MODE ###### //
 #endif
@@ -170,7 +171,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(value.GetCommandClassId());
     emitinfo[3] = valobj;
-    emit_cb->Call(4, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 4, emitinfo);
     break;
   }
   //                            ##################
@@ -191,7 +192,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[2] = Nan::New<Integer>(value.GetCommandClassId());
     emitinfo[3] = Nan::New<Integer>(value.GetInstance());
     emitinfo[4] = Nan::New<Integer>(value.GetIndex());
-    emit_cb->Call(5, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 5, emitinfo);
     break;
   }
   //                            ##################
@@ -203,7 +204,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(value.GetCommandClassId());
     emitinfo[3] = valobj;
-    emit_cb->Call(4, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 4, emitinfo);
     break;
   }
   //                            ####################
@@ -215,7 +216,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(value.GetCommandClassId());
     emitinfo[3] = valobj;
-    emit_cb->Call(4, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 4, emitinfo);
     break;
   }
   //                            #############
@@ -241,7 +242,7 @@ void handleNotification(NotifInfo *notif)
     }
     emitinfo[0] = Nan::New<String>("node added").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
-    emit_cb->Call(2, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 2, emitinfo);
     break;
   }
   //                            #################
@@ -253,7 +254,7 @@ void handleNotification(NotifInfo *notif)
     }
     emitinfo[0] = Nan::New<String>("node removed").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
-    emit_cb->Call(2, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 2, emitinfo);
     break;
   }
   //                            ######################
@@ -272,7 +273,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("node naming").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = cbinfo;
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   //                            ###############
@@ -282,7 +283,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(notif->event);
     emitinfo[3] = Nan::New<String>(notif->help.c_str()).ToLocalChecked();
-    emit_cb->Call(4, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 4, emitinfo);
     break;
   }
   //                            #####################
@@ -292,7 +293,7 @@ void handleNotification(NotifInfo *notif)
       node->polled = false;
       emitinfo[0] = Nan::New<String>("polling disabled").ToLocalChecked();
       emitinfo[1] = Nan::New<Integer>(notif->nodeid);
-      emit_cb->Call(2, emitinfo);
+      emit_cb->Call(Nan::New(ctx_obj), 2, emitinfo);
     }
     break;
   }
@@ -303,7 +304,7 @@ void handleNotification(NotifInfo *notif)
       node->polled = true;
       emitinfo[0] = Nan::New<String>("polling enabled").ToLocalChecked();
       emitinfo[1] = Nan::New<Integer>(notif->nodeid);
-      emit_cb->Call(2, emitinfo);
+      emit_cb->Call(Nan::New(ctx_obj), 2, emitinfo);
     }
     break;
   }
@@ -313,7 +314,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("scene event").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(notif->sceneid);
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   //                            ##################
@@ -322,7 +323,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("create button").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(notif->buttonid);
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   //                            ##################
@@ -331,7 +332,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("delete button").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(notif->buttonid);
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   //                            ##############
@@ -340,7 +341,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("button on").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(notif->buttonid);
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   //                            ###############
@@ -349,7 +350,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("button off").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(notif->buttonid);
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   //                            #################
@@ -359,14 +360,14 @@ void handleNotification(NotifInfo *notif)
     homeid = notif->homeid;
     emitinfo[0] = Nan::New<String>("driver ready").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(homeid);
-    emit_cb->Call(2, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 2, emitinfo);
     break;
   }
   //                            ##################
   case OpenZWave::Notification::Type_DriverFailed: {
     //                            ##################
     emitinfo[0] = Nan::New<String>("driver failed").ToLocalChecked();
-    emit_cb->Call(1, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 1, emitinfo);
     break;
   }
   //                            ##################################
@@ -376,7 +377,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("node available").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = cbinfo;
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   /*
@@ -389,7 +390,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[0] = Nan::New<String>("node ready").ToLocalChecked();
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = cbinfo;
-    emit_cb->Call(3, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 3, emitinfo);
     break;
   }
   /*
@@ -402,7 +403,7 @@ void handleNotification(NotifInfo *notif)
   case OpenZWave::Notification::Type_AllNodesQueriedSomeDead: {
     //                            #############################
     emitinfo[0] = Nan::New<String>("scan complete").ToLocalChecked();
-    emit_cb->Call(1, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 1, emitinfo);
     break;
   }
   //                            ##################
@@ -412,7 +413,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[1] = Nan::New<Integer>(notif->nodeid);
     emitinfo[2] = Nan::New<Integer>(notif->notification);
     emitinfo[3] = Nan::New<String>(notif->help.c_str()).ToLocalChecked();
-    emit_cb->Call(4, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 4, emitinfo);
     break;
   }
   case OpenZWave::Notification::Type_DriverRemoved:
@@ -431,7 +432,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[3] =
         Nan::New<Integer>(notif->notification); // Driver::ControllerState
     emitinfo[4] = Nan::New<String>(notif->help.c_str()).ToLocalChecked();
-    emit_cb->Call(5, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 5, emitinfo);
     break;
   case OpenZWave::Notification::Type_NodeReset:
     emitinfo[0] = Nan::New<String>("node reset").ToLocalChecked();
@@ -439,7 +440,7 @@ void handleNotification(NotifInfo *notif)
     emitinfo[2] = Nan::New<Integer>(notif->event); // Driver::ControllerCommand
     emitinfo[3] =
         Nan::New<Integer>(notif->notification); // Driver::ControllerState
-    emit_cb->Call(4, emitinfo);
+    emit_cb->Call(Nan::New(ctx_obj), 4, emitinfo);
     break;
 #endif
   default:

--- a/src/callbacks.hpp
+++ b/src/callbacks.hpp
@@ -61,6 +61,7 @@ namespace OZW {
 
   //extern Handle<Object>	context_obj;
   extern Nan::Callback *emit_cb;
+  extern Nan::CopyablePersistentTraits<v8::Object>::CopyablePersistent ctx_obj;
 
   /*
   * uv_async to let the OpenZWave callback wake up the main V8 thread

--- a/src/openzwave-driver.cc
+++ b/src/openzwave-driver.cc
@@ -55,7 +55,7 @@ namespace OZW {
 		cbinfo[0] = Nan::New<String>("connected").ToLocalChecked();
 		cbinfo[1] = Nan::New<String>(version).ToLocalChecked();
 
-		emit_cb->Call(2, cbinfo);
+		emit_cb->Call(Nan::New(ctx_obj), 2, cbinfo);
 	}
 
 	// ===================================================================

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -249,6 +249,8 @@ namespace OZW {
 		self->userpath = ozw_userpath;
 		self->option_overrides = option_overrides;
 
+		ctx_obj = Nan::Persistent<Object>(info.This());
+
 		//
 		info.GetReturnValue().Set(info.This());
 	}


### PR DESCRIPTION
And correctly set `this` to the instance of OZW when calling `emit`.

Fixes:
#161
#160
#169
#176
#177

We're now keeping a reference around which we can set as the target when calling `emit` from the async handlers. This is the main reason why the solution in #161 didn't work.