### PR TITLE
Fix deprecations to remove the compile warnings

### DIFF
--- a/src/openzwave-config.cc
+++ b/src/openzwave-config.cc
@@ -29,14 +29,14 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(3, "nodeid, param, value");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 param  = info[1]->ToNumber()->Value();
-		int32 value  = info[2]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 param  = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
+		int32 value  = Nan::To<Number>(info[2]).ToLocalChecked()->Value();
 		if (info.Length() < 4) {
 			OpenZWave::Manager::Get()->SetConfigParam(homeid, nodeid, param, value);
 		}
 		else {
-			uint8 size = info[3]->ToNumber()->Value();
+			uint8 size = Nan::To<Number>(info[3]).ToLocalChecked()->Value();
 			OpenZWave::Manager::Get()->SetConfigParam(homeid, nodeid, param, value, size);
 		}
 	}
@@ -62,8 +62,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, param");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 param = info[1]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 param = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
 		OpenZWave::Manager::Get()->RequestConfigParam(homeid, nodeid, param);
 	}
 
@@ -78,7 +78,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		OpenZWave::Manager::Get()->RequestAllConfigParams (homeid, nodeid);
 	}
 

--- a/src/openzwave-driver.cc
+++ b/src/openzwave-driver.cc
@@ -31,6 +31,9 @@ namespace OZW {
 
 		std::string path = (*String::Utf8Value(info[0]->ToString()));
 
+    uint8 tst = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
+		std::cout << "test: (" << unsigned(tst) << ")\n";
+
 		uv_async_init(uv_default_loop(), &async, async_cb_handler);
 
 		Local<Function> callbackHandle = Nan::Get( info.This(),

--- a/src/openzwave-driver.cc
+++ b/src/openzwave-driver.cc
@@ -31,9 +31,6 @@ namespace OZW {
 
 		std::string path = (*String::Utf8Value(info[0]->ToString()));
 
-    uint8 tst = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
-		std::cout << "test: (" << unsigned(tst) << ")\n";
-
 		uv_async_init(uv_default_loop(), &async, async_cb_handler);
 
 		Local<Function> callbackHandle = Nan::Get( info.This(),

--- a/src/openzwave-groups.cc
+++ b/src/openzwave-groups.cc
@@ -33,7 +33,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint8 numGroups = OpenZWave::Manager::Get()->GetNumGroups(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Integer>(numGroups));
 	}
@@ -48,8 +48,8 @@ namespace OZW {
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, groupidx");
 		uint8* associations;
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 groupidx = info[1]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 groupidx = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
 
 		uint32 numNodes = OpenZWave::Manager::Get()->GetAssociations(
 			homeid, nodeid,	groupidx, &associations
@@ -77,8 +77,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, groupidx");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 groupidx = info[1]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 groupidx = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
 
 		uint8 numMaxAssoc = OpenZWave::Manager::Get()->GetMaxAssociations(
 			homeid, nodeid,	groupidx
@@ -96,8 +96,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, groupidx");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 groupidx = info[1]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 groupidx = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
 
 		std::string groupLabel = OpenZWave::Manager::Get()->GetGroupLabel(
 			homeid, nodeid, groupidx
@@ -118,9 +118,9 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(3, "nodeid, groupidx, tgtnodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 groupidx = info[1]->ToNumber()->Value();
-		uint8 tgtnodeid = info[2]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 groupidx = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
+		uint8 tgtnodeid = Nan::To<Number>(info[2]).ToLocalChecked()->Value();
 
 		OpenZWave::Manager::Get()->AddAssociation(
 			homeid,nodeid,groupidx,tgtnodeid
@@ -136,9 +136,9 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(3, "nodeid, groupidx, tgtnodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 groupidx = info[1]->ToNumber()->Value();
-		uint8 tgtnodeid = info[2]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 groupidx = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
+		uint8 tgtnodeid = Nan::To<Number>(info[2]).ToLocalChecked()->Value();
 
 		OpenZWave::Manager::Get()->RemoveAssociation(homeid,nodeid,groupidx,tgtnodeid);
 	}

--- a/src/openzwave-management.cc
+++ b/src/openzwave-management.cc
@@ -299,7 +299,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "command");
-		std::string ctrcmd = (*String::Utf8Value(Nan::To<String>(info[0]).ToLocalChecked()->Value()));
+		std::string ctrcmd = (*String::Utf8Value(Nan::To<String>(info[0]).ToLocalChecked()));
 		uint8 nodeid1 = 0xff;
 		uint8 nodeid2 = 0;
 		bool highpower = false;

--- a/src/openzwave-management.cc
+++ b/src/openzwave-management.cc
@@ -38,7 +38,7 @@ namespace OZW {
 	// =================================================================
 	{
 		Nan::HandleScope scope;
-		bool doSecurity = info.Length() > 0 && info[0]->ToBoolean()->Value();
+		bool doSecurity = info.Length() > 0 && Nan::To<Boolean>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->AddNode(homeid, doSecurity)
 		));
@@ -74,7 +74,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->RemoveFailedNode(homeid, nodeid)
 		));
@@ -93,7 +93,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->HasNodeFailed(homeid, nodeid)
 		));
@@ -109,7 +109,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->RequestNodeNeighborUpdate(homeid, nodeid)
 		));
@@ -125,7 +125,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->AssignReturnRoute(homeid, nodeid)
 		));
@@ -142,7 +142,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->DeleteAllReturnRoutes(homeid, nodeid)
 		));
@@ -158,7 +158,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->SendNodeInformation(homeid, nodeid)
 		));
@@ -206,7 +206,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->ReplaceFailedNode(homeid, nodeid)
 		));
@@ -235,7 +235,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->RequestNetworkUpdate(homeid, nodeid)
 		));
@@ -250,7 +250,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->ReplicationSend(homeid, nodeid)
 		));
@@ -265,8 +265,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, buttonid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 btnid = info[1]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 btnid = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->CreateButton(homeid, nodeid, btnid)
 		));
@@ -281,8 +281,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, buttonid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 btnid = info[1]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 btnid = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
 		info.GetReturnValue().Set(Nan::New<Boolean>(
 			OpenZWave::Manager::Get()->DeleteButton(homeid, nodeid, btnid)
 		));
@@ -299,16 +299,16 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "command");
-		std::string ctrcmd = (*String::Utf8Value(info[0]->ToString()));
+		std::string ctrcmd = (*String::Utf8Value(Nan::To<String>(info[0]).ToLocalChecked()->Value()));
 		uint8 nodeid1 = 0xff;
 		uint8 nodeid2 = 0;
 		bool highpower = false;
 		if (info.Length() > 1) {
-			highpower = info[1]->ToBoolean()->Value();
+			highpower = Nan::To<Boolean>(info[1]).ToLocalChecked()->Value();
 			if (info.Length() > 2) {
-				nodeid1 = info[2]->ToNumber()->Value();
+				nodeid1 = Nan::To<Number>(info[2]).ToLocalChecked()->Value();
 				if (info.Length() > 3) {
-					nodeid2 = info[3]->ToNumber()->Value();
+					nodeid2 = Nan::To<Number>(info[3]).ToLocalChecked()->Value();
 				}
 			}
 		}
@@ -400,7 +400,7 @@ namespace OZW {
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
 		OpenZWave::Node::NodeData data;
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 
 		OpenZWave::Manager::Get()->GetNodeStatistics(homeid, nodeid, &data);
 

--- a/src/openzwave-network.cc
+++ b/src/openzwave-network.cc
@@ -31,8 +31,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 nummsg = (info.Length() > 1) ? info[1]->ToNumber()->Value() : 1;
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 nummsg = (info.Length() > 1) ? Nan::To<Number>(info[1]).ToLocalChecked()->Value() : 1;
 		OpenZWave::Manager::Get()->TestNetworkNode(homeid, nodeid, nummsg);
 	}
 
@@ -45,7 +45,7 @@ namespace OZW {
 	// ===================================================================
 	{
 		Nan::HandleScope scope;
-		uint8 nummsg = (info.Length() > 0) ? info[0]->ToNumber()->Value() : 1;
+		uint8 nummsg = (info.Length() > 0) ? Nan::To<Number>(info[0]).ToLocalChecked()->Value() : 1;
 		OpenZWave::Manager::Get()->TestNetwork(homeid, nummsg);
 	}
 
@@ -58,8 +58,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		uint8 doRR = (info.Length() > 1) ? info[1]->ToBoolean()->Value() : false;
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 doRR = (info.Length() > 1) ? Nan::To<Boolean>(info[1]).ToLocalChecked()->Value() : false;
 		OpenZWave::Manager::Get()->HealNetworkNode(homeid, nodeid, doRR);
 	}
 
@@ -73,7 +73,7 @@ namespace OZW {
 	// ===================================================================
 	{
 		Nan::HandleScope scope;
-		bool doRR = (info.Length() > 0) ? info[0]->ToBoolean()->Value() : false;
+		bool doRR = (info.Length() > 0) ? Nan::To<Boolean>(info[0]).ToLocalChecked()->Value() : false;
 		OpenZWave::Manager::Get()->HealNetwork(homeid, doRR);
 	}
 }

--- a/src/openzwave-nodes.cc
+++ b/src/openzwave-nodes.cc
@@ -31,7 +31,7 @@ namespace OZW {
 		Nan::HandleScope scope;
 		uint8* neighbors;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint8 numNeighbors = OpenZWave::Manager::Get()->GetNodeNeighbors(homeid, nodeid, &neighbors);
 		Local<Array> o_neighbors = Nan::New<Array>(numNeighbors);
 		if (numNeighbors > 0) {
@@ -49,7 +49,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		OpenZWave::Manager::Get()->SetNodeOn(homeid, nodeid);
 	}
 
@@ -59,7 +59,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		OpenZWave::Manager::Get()->SetNodeOff(homeid, nodeid);
 	}
 
@@ -70,8 +70,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, level");
-		uint8 nodeid = info[0]->ToInteger()->Value();
-		uint8 level  = info[1]->ToInteger()->Value();
+		uint8 nodeid = Nan::To<Integer>(info[0]).ToLocalChecked()->Value();
+		uint8 level  = Nan::To<Integer>(info[1]).ToLocalChecked()->Value();
     printf("Setting home %x node %d level %d\n", homeid , nodeid, level);
 		OpenZWave::Manager::Get()->SetNodeLevel(homeid, nodeid, level);
 	}
@@ -122,8 +122,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, location");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		std::string location = (*String::Utf8Value(info[1]->ToString()));
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		std::string location = (*String::Utf8Value(Nan::To<String>(info[1]).ToLocalChecked()));
 		OpenZWave::Manager::Get()->SetNodeLocation(homeid, nodeid, location);
 	}
 
@@ -136,8 +136,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "nodeid, name");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		std::string name = (*String::Utf8Value(info[1]->ToString()));
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		std::string name = (*String::Utf8Value(Nan::To<String>(info[1]).ToLocalChecked()));
 		OpenZWave::Manager::Get()->SetNodeName(homeid, nodeid, name);
 	}
 
@@ -157,7 +157,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		OpenZWave::Manager::Get()->RefreshNodeInfo(homeid, nodeid);
 	}
 
@@ -170,7 +170,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeManufacturerName(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -184,7 +184,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		bool result = OpenZWave::Manager::Get()->RequestNodeState(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Boolean>(result));
 	}
@@ -198,7 +198,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		bool result = OpenZWave::Manager::Get()->RequestNodeDynamic(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Boolean>(result));
 	}
@@ -212,7 +212,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		bool result = OpenZWave::Manager::Get()->IsNodeListeningDevice(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Boolean>(result));
 	}
@@ -226,7 +226,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		bool result = OpenZWave::Manager::Get()->IsNodeFrequentListeningDevice(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Boolean>(result));
 	}
@@ -240,7 +240,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		bool result = OpenZWave::Manager::Get()->IsNodeBeamingDevice(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Boolean>(result));
 	}
@@ -254,7 +254,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		bool result = OpenZWave::Manager::Get()->IsNodeRoutingDevice(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Boolean>(result));
 	}
@@ -268,7 +268,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		bool result = OpenZWave::Manager::Get()->IsNodeSecurityDevice(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Boolean>(result));
 	}
@@ -282,7 +282,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8  nodeid = info[0]->ToNumber()->Value();
+		uint8  nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint32 result = OpenZWave::Manager::Get()->GetNodeMaxBaudRate(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Uint32>(result));
 	}
@@ -296,7 +296,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint8 result = OpenZWave::Manager::Get()->GetNodeVersion(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Integer>(result));
 	}
@@ -310,7 +310,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint8 result = OpenZWave::Manager::Get()->GetNodeSecurity(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Integer>(result));
 	}
@@ -324,7 +324,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint8 result = OpenZWave::Manager::Get()->GetNodeBasic(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Integer>(result));
 	}
@@ -338,7 +338,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint8 result = OpenZWave::Manager::Get()->GetNodeGeneric(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Integer>(result));
 	}
@@ -352,7 +352,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		uint8 result = OpenZWave::Manager::Get()->GetNodeSpecific(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<Integer>(result));
 	}
@@ -366,7 +366,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeType(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -380,7 +380,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeProductName(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -394,7 +394,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeName(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -408,7 +408,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeLocation(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -422,7 +422,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeManufacturerId(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -436,7 +436,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeProductType(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -450,7 +450,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		std::string result = OpenZWave::Manager::Get()->GetNodeProductId(homeid, nodeid);
 		info.GetReturnValue().Set(Nan::New<String>(result.c_str()).ToLocalChecked());
 	}
@@ -464,8 +464,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		std::string name = (*String::Utf8Value(info[1]->ToString()));
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		std::string name = (*String::Utf8Value(Nan::To<String>(info[1]).ToLocalChecked()));
 		OpenZWave::Manager::Get()->SetNodeManufacturerName(homeid, nodeid, name);
 	}
 
@@ -478,8 +478,8 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "nodeid");
-		uint8 nodeid = info[0]->ToNumber()->Value();
-		std::string name = (*String::Utf8Value(info[1]->ToString()));
+		uint8 nodeid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		std::string name = (*String::Utf8Value(Nan::To<String>(info[1]).ToLocalChecked()));
 		OpenZWave::Manager::Get()->SetNodeProductName(homeid, nodeid, name);
 	}
 

--- a/src/openzwave-polling.cc
+++ b/src/openzwave-polling.cc
@@ -49,7 +49,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "intervalMillisecs");
-		uint32 intervalMillisecs = info[0]->ToNumber()->Value();
+		uint32 intervalMillisecs = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		OpenZWave::Manager::Get()->SetPollInterval (intervalMillisecs, false);
 	}
 
@@ -65,7 +65,7 @@ namespace OZW {
 		OpenZWave::ValueID* vit = populateValueId(info);
 		bool b = false;
 		if (vit) {
-			uint8 intensity = (info.Length() > 4) ? info[4]->ToNumber()->Value() : 1;
+			uint8 intensity = (info.Length() > 4) ? Nan::To<Number>(info[4]).ToLocalChecked()->Value() : 1;
 			b = OpenZWave::Manager::Get()->EnablePoll((*vit), intensity);
 		}
 		info.GetReturnValue().Set(Nan::New<Boolean>(b));
@@ -109,7 +109,7 @@ namespace OZW {
 		uint8 intensity;
 		if (ozwvid) {
 			uint8 intensity_index = ( info[0]->IsObject() ) ? 1 : 4;
-			intensity = info[intensity_index]->ToNumber()->Value();
+			intensity = Nan::To<Number>(info[intensity_index]).ToLocalChecked()->Value();
 			OpenZWave::Manager::Get()->SetPollIntensity (*ozwvid, intensity);
 		}
 	}

--- a/src/openzwave-scenes.cc
+++ b/src/openzwave-scenes.cc
@@ -29,7 +29,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "label");
-		std::string label = (*String::Utf8Value(info[0]->ToString()));
+		std::string label = (*String::Utf8Value(Nan::To<String>(info[0]).ToLocalChecked()));
 		SceneInfo *scene;
 
 		uint8 sceneid = OpenZWave::Manager::Get()->CreateScene();
@@ -52,7 +52,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "sceneid");
-		uint8 sceneid = info[0]->ToNumber()->Value();
+		uint8 sceneid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		SceneInfo *scene;
 
 		if ((scene = get_scene_info(sceneid))) {
@@ -118,50 +118,50 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "sceneid, value");
-		uint8 sceneid  = info[0]->ToNumber()->Value();
+		uint8 sceneid  = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		OpenZWave::ValueID* vit = populateValueId(info, 1);
 		if (vit) {
 			uint8 valoffset = ( info[1]->IsObject() ) ? 2 : 5;
 			switch ((*vit).GetType()) {
 				case OpenZWave::ValueID::ValueType_Bool: {
 					//bool val; OpenZWave::Manager::Get()->GetValueAsBool(*vit, &val);
-					bool val = info[valoffset]->ToBoolean()->Value();
+					bool val = Nan::To<Boolean>(info[valoffset]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Byte: {
 					//uint8 val; OpenZWave::Manager::Get()->GetValueAsByte(*vit, &val);
-					uint8 val = info[valoffset]->ToInteger()->Value();
+					uint8 val = Nan::To<Integer>(info[valoffset]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Decimal: {
 					//float val; OpenZWave::Manager::Get()->GetValueAsFloat(*vit, &val);
-					float val = info[valoffset]->ToNumber()->NumberValue();
+					float val = Nan::To<Number>(info[valoffset]).ToLocalChecked()->NumberValue();
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Int: {
 					//uint32 val; OpenZWave::Manager::Get()->GetValueAsInt(*vit, &val);
-					int32 val = info[valoffset]->ToInteger()->Value();
+					int32 val = Nan::To<Integer>(info[valoffset]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_List: {
 					//std::string val; OpenZWave::Manager::Get()->GetValueListSelection(*vit, &val);
-					std::string val = (*String::Utf8Value(info[valoffset]->ToString()));
+					std::string val = (*String::Utf8Value(Nan::To<String>(info[valoffset]).ToLocalChecked()));
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Short: {
 					//int16_t val; OpenZWave::Manager::Get()->GetValueAsShort(*vit, &val);
-					uint16 val = info[valoffset]->ToInteger()->Value();
+					uint16 val = Nan::To<Integer>(info[valoffset]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_String: {
 					//std::string val; OpenZWave::Manager::Get()->GetValueAsString(*vit, &val);
-					std::string val = (*String::Utf8Value(info[valoffset]->ToString()));
+					std::string val = (*String::Utf8Value(Nan::To<String>(info[valoffset]).ToLocalChecked()));
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
@@ -184,7 +184,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(2, "sceneid, value");
-		uint8 sceneid = info[0]->ToNumber()->Value();
+		uint8 sceneid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		SceneInfo *scene;
 		if ((scene = get_scene_info(sceneid))) {
 			OpenZWave::ValueID* vit = populateValueId(info, 1);
@@ -201,7 +201,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "sceneid");
-		uint8 sceneid = info[0]->ToNumber()->Value();
+		uint8 sceneid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 
 		std::vector<OpenZWave::ValueID> values;
 		std::vector<OpenZWave::ValueID>::iterator vit;
@@ -231,7 +231,7 @@ namespace OZW {
 	{
 		Nan::HandleScope scope;
 		CheckMinArgs(1, "sceneid");
-		uint8 sceneid = info[0]->ToNumber()->Value();
+		uint8 sceneid = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
 		SceneInfo *scene;
 
 		if ((scene = get_scene_info(sceneid))) {

--- a/src/openzwave-values.cc
+++ b/src/openzwave-values.cc
@@ -36,37 +36,37 @@ namespace OZW {
 			uint8 validx  =  (info[0]->IsObject()) ? 1 : 4;
 			switch ((*vit).GetType()) {
 				case OpenZWave::ValueID::ValueType_Bool: {
-					bool val = info[validx]->BooleanValue();
+					bool val = Nan::To<Boolean>(info[validx]).ToLocalChecked()->Value();
 					mgr->SetValue(*vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Byte: {
-					uint8 val = info[validx]->ToInteger()->Value();
+					uint8 val = Nan::To<Integer>(info[validx]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->SetValue(*vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Decimal: {
-					float val = info[validx]->ToNumber()->NumberValue();
+					float val = Nan::To<Number>(info[validx]).ToLocalChecked()->NumberValue();
 					OpenZWave::Manager::Get()->SetValue(*vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Int: {
-					int32 val = info[validx]->ToInteger()->Value();
+					int32 val = Nan::To<Integer>(info[validx]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->SetValue(*vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_List: {
-					std::string val = (*String::Utf8Value(info[validx]->ToString()));
+					std::string val = (*String::Utf8Value(Nan::To<String>(info[validx]).ToLocalChecked()));
 					OpenZWave::Manager::Get()->SetValue(*vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Short: {
-					int16 val = info[validx]->ToInteger()->Value();
+					int16 val = Nan::To<Integer>(info[validx]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->SetValue(*vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_String: {
-					std::string val = (*String::Utf8Value(info[validx]->ToString()));
+					std::string val = (*String::Utf8Value(Nan::To<String>(info[validx]).ToLocalChecked()));
 					OpenZWave::Manager::Get()->SetValue(*vit, val);
 					break;
 				}
@@ -121,7 +121,7 @@ namespace OZW {
 			const uint8 validx = (info[0]->IsObject()) ? 1 : 4;
 			if (checkType(info[validx]->IsBoolean())) {
 				OpenZWave::Manager* mgr = OpenZWave::Manager::Get();
-				mgr->SetChangeVerified(*vit, info[validx]->BooleanValue());
+				mgr->SetChangeVerified(*vit, Nan::To<Boolean>(info[validx]).ToLocalChecked()->Value());
 			}
 		}
 	}
@@ -164,7 +164,7 @@ namespace OZW {
 			if ((info.Length() < idxpos) || !info[idxpos]->IsNumber()) {
 				Nan::ThrowTypeError("must supply an integer index after the valueId");
 			} else {
-				idx = info[idxpos]->ToNumber()->Value();
+				idx = Nan::To<Number>(info[idxpos]).ToLocalChecked()->Value();
 				OpenZWave::Manager::Get()->GetSwitchPoint(*vit, idx, &o_hours, &o_minutes, &o_setback);
 				Local<Object> o  = Nan::New<Object>();
 				Nan::Set(o,
@@ -215,9 +215,9 @@ namespace OZW {
 				} else {
 					Local<Object> sp = info[idxpos]->ToObject();
 					OpenZWave::Manager::Get()->SetSwitchPoint(*vit,
-						Nan::Get(sp, Nan::New<String>("hours").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value(),
-						Nan::Get(sp, Nan::New<String>("minutes").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value(),
-						Nan::Get(sp, Nan::New<String>("setback").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value()
+						Nan::To<Number>(Nan::Get(sp, Nan::New<String>("hours").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value(),
+						Nan::To<Number>(Nan::Get(sp, Nan::New<String>("minutes").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value(),
+						Nan::To<Number>(Nan::Get(sp, Nan::New<String>("setback").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value()
 					);
 				}
 			}
@@ -239,10 +239,10 @@ namespace OZW {
 				if ((info.Length() < idxpos) || !info[idxpos]->IsObject()) {
 					Nan::ThrowTypeError("must supply a switchpoint object ");
 				} else {
-					Local<Object> sp = info[idxpos]->ToObject();
+					Local<Object> sp = Nan::To<Object>(info[idxpos]).ToLocalChecked();
 					OpenZWave::Manager::Get()->RemoveSwitchPoint(*vit,
-						Nan::Get(sp, Nan::New<String>("hours").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value(),
-						Nan::Get(sp, Nan::New<String>("minutes").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value()
+						Nan::To<Number>(Nan::Get(sp, Nan::New<String>("hours").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value(),
+						Nan::To<Number>(Nan::Get(sp, Nan::New<String>("minutes").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value()
 					);
 				}
 			}

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -211,7 +211,7 @@ namespace OZW {
 		std::string option_overrides;
 		// Options are global for all drivers and can only be set once.
 		if (info.Length() > 0) {
-			Local < Object > opts = info[0]->ToObject();
+			Local < Object > opts = Nan::To<Object>(info[0]).ToLocalChecked();
 			Local < Array > props = Nan::GetOwnPropertyNames(opts).ToLocalChecked();
 			for (unsigned int i = 0; i < props->Length(); ++i) {
 				Local<Value> key       = props->Get(i);

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -26,12 +26,12 @@
 #include <v8.h>
 #include "nan.h"
 
-#include "Manager.h"
-#include "Driver.h"
-#include "Node.h"
-#include "Notification.h"
-#include "Options.h"
-#include "Value.h"
+#include "openzwave/Manager.h"
+#include "openzwave/Driver.h"
+#include "openzwave/Node.h"
+#include "openzwave/Notification.h"
+#include "openzwave/Options.h"
+#include "openzwave/value_classes/Value.h"
 
 #if defined(_WIN32) || defined( __APPLE__)
     #include <unordered_map>

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -288,12 +288,12 @@ namespace OZW {
 	OpenZWave::ValueID* populateValueId(const Nan::FunctionCallbackInfo<v8::Value> &info, uint8 offset) {
 		uint8 nodeid, comclass, instance, index;
 		if ( (info.Length() >= offset) && info[offset]->IsObject() ) {
-			Local<Object> o = info[offset]->ToObject();
+			Local<Object> o = Nan::To<Object>(info[offset]).ToLocalChecked();
 			if (isOzwValue(o)) {
-				nodeid   = Nan::Get(o, Nan::New<String>("node_id").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
-				comclass = Nan::Get(o, Nan::New<String>("class_id").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
-				instance = Nan::Get(o, Nan::New<String>("instance").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
-				index    = Nan::Get(o, Nan::New<String>("index").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
+				nodeid   = Nan::To<Number>(Nan::Get(o, Nan::New<String>("node_id").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value();
+				comclass = Nan::To<Number>(Nan::Get(o, Nan::New<String>("class_id").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value();
+				instance = Nan::To<Number>(Nan::Get(o, Nan::New<String>("instance").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value();
+				index    = Nan::To<Number>(Nan::Get(o, Nan::New<String>("index").ToLocalChecked()).ToLocalChecked()).ToLocalChecked()->Value();
 			} else {
 				std::string errmsg("OpenZWave valueId object not found: ");
 				Nan::JSON NanJSON;
@@ -307,10 +307,10 @@ namespace OZW {
 			}
 		} else if ((info.Length() >= offset+4)) {
 			// legacy mode
-			nodeid   = info[offset]->ToNumber()->Value();
-			comclass = info[offset+1]->ToNumber()->Value();
-			instance = info[offset+2]->ToNumber()->Value();
-			index    = info[offset+3]->ToNumber()->Value();
+			nodeid   = Nan::To<Number>(info[offset]).ToLocalChecked()->Value();
+			comclass = Nan::To<Number>(info[offset+1]).ToLocalChecked()->Value();
+			instance = Nan::To<Number>(info[offset+2]).ToLocalChecked()->Value();
+			index    = Nan::To<Number>(info[offset+3]).ToLocalChecked()->Value();
 		} else {
 			std::string errmsg("OpenZWave valueId not found. Pass either a JS object with {node_id, class_id, instance, index} or the raw values in this order.");
 			Nan::ThrowTypeError(errmsg.c_str());


### PR DESCRIPTION
Sorry about the flood with PRs. We're using this library heavily and we're just happy to give something back. Keep up the good work! 👍 

This PR fixes the various deprecation warnings when building the addon.

All value conversions are now deprecated and the `Maybe` version is [suggested](https://v8docs.nodesource.com/node-8.0/dc/d0a/classv8_1_1_value.html).