### PR TITLE
Release lock during handleNotification call

### DIFF
--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -462,6 +462,8 @@ void async_cb_handler(uv_async_t *handle)
 
   while (!zqueue.empty()) {
     notif = zqueue.front();
+    zqueue.pop();
+    zqueue_mutex.unlock();
 #if OPENZWAVE_SECURITY != 1
     if (notif->homeid == 0) {
       handleControllerCommand(notif);
@@ -471,8 +473,8 @@ void async_cb_handler(uv_async_t *handle)
 #else
     handleNotification(notif);
 #endif
+    zqueue_mutex.lock();
     delete notif;
-    zqueue.pop();
   }
 }
 


### PR DESCRIPTION
This allows event handlers to invoke methods which may result in additional events without deadlocking.

Fixes #182 