### PR TITLE
Fix path detection for partial failures

### DIFF
--- a/lib/ozwpaths.js
+++ b/lib/ozwpaths.js
@@ -29,6 +29,7 @@ function doScript(script, suppressException) {
   } catch(e) {
     //console.log('---> ' + e.toString());
     if (!suppressException) throw e;
+    if (e.stdout) return e.stdout.toString();
   }
 }
 


### PR DESCRIPTION
Return stdout on exception when suppressException is true. When running `find` in a directory like `/etc/`, find may return a non-zero error code because of permissions on unrelated subdirectories but still find the files we're looking for.