### PR TITLE
Fixing a common coexistence issue. Look for the newest node referece first.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -48,7 +48,7 @@
 	        }],
 			["OS=='linux'", {
 				"variables": {
-					"NODE"            : "<!(which nodejs || which node)",
+					"NODE"            : "<!(which node || which nodejs)",
 					"OZW_INC"         : "<!(<(NODE) -p \"require('./lib/ozwpaths.js').includedir || '/usr/*/include'\")",
 					"OZW_LIB_PATH"    : "<!(<(NODE) -p \"require('./lib/ozwpaths.js').libdir\")",
 					"OZW_ETC"         : "<!(<(NODE) -p \"require('./lib/ozwpaths.js').sysconfdir\")",


### PR DESCRIPTION
This line is causing the common Raspberry Pi build issue. Users who have two versions of node.js in their path can cause confusion in this script.