### PR TITLE
Fix in EnablePoll method, it instead of getting a value from index 1,…

### DIFF
--- a/src/openzwave-polling.cc
+++ b/src/openzwave-polling.cc
@@ -65,7 +65,9 @@ namespace OZW {
 		OpenZWave::ValueID* vit = populateValueId(info);
 		bool b = false;
 		if (vit) {
-			uint8 intensity = (info.Length() > 4) ? Nan::To<Number>(info[4]).ToLocalChecked()->Value() : 1;
+			uint8 idxpos  =  (info[0]->IsObject()) ? 1 : 4;
+			uint8 intensity = Nan::To<Number>(info[idxpos]).ToLocalChecked()->Value();
+
 			b = OpenZWave::Manager::Get()->EnablePoll((*vit), intensity);
 		}
 		info.GetReturnValue().Set(Nan::New<Boolean>(b));


### PR DESCRIPTION
It does look like a bug.

API supports "old" and "new" ways of passing value_id - as an object or as 4 arguments.
Each such "dual-API"  method does a check of input arguments to determine if that is "old" or "new" style of invocation.

And in "EnablePoll" method, it does look like a bug to me - instead of getting value from 1-st position, it just gets 1.
