### PR TITLE
Add LogInitialisation boolean option

### DIFF
--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -209,6 +209,7 @@ namespace OZW {
 		OZW* self = new OZW();
 		self->Wrap(info.This());
 		std::string option_overrides;
+		bool log_initialisation = true;
 		// Options are global for all drivers and can only be set once.
 		if (info.Length() > 0) {
 			Local < Object > opts = Nan::To<Object>(info[0]).ToLocalChecked();
@@ -224,26 +225,30 @@ namespace OZW {
 					ozw_userpath.assign(argvalstr);
 				} else if (keyname == "ConfigPath") {
 					ozw_config_path.assign(argvalstr);
+				} else if (keyname == "LogInitialisation") {
+					log_initialisation = argval->BooleanValue();
 				} else {
 					option_overrides += " --" + keyname + " " + argvalstr;
 				}
 			}
 		}
 
-		std::ostringstream versionstream;
-		versionstream << ozw_vers_major << "." << ozw_vers_minor << "." << ozw_vers_revision;
-		std::cout << "Initialising OpenZWave " << versionstream.str() << " binary addon for Node.JS.\n";
+		if (log_initialisation) {
+			std::ostringstream versionstream;
+			versionstream << ozw_vers_major << "." << ozw_vers_minor << "." << ozw_vers_revision;
+			std::cout << "Initialising OpenZWave " << versionstream.str() << " binary addon for Node.JS.\n";
 
 #if OPENZWAVE_SECURITY == 1
-		std::cout << "\tOpenZWave Security API is ENABLED\n";
+			std::cout << "\tOpenZWave Security API is ENABLED\n";
 #else
-		std::cout << "\tSecurity API not found, using legacy BeginControllerCommand() instead\n";
+			std::cout << "\tSecurity API not found, using legacy BeginControllerCommand() instead\n";
 #endif
 
-		std::cout << "\tZWave device db    : " << ozw_config_path << "\n";
-		std::cout << "\tUser settings path : " << ozw_userpath << "\n";
-		if (option_overrides.length() > 0) {
-			std::cout << "\tOption Overrides :" << option_overrides << "\n";
+			std::cout << "\tZWave device db    : " << ozw_config_path << "\n";
+			std::cout << "\tUser settings path : " << ozw_userpath << "\n";
+			if (option_overrides.length() > 0) {
+				std::cout << "\tOption Overrides :" << option_overrides << "\n";
+			}
 		}
 
 		// Store configuration data for connect.


### PR DESCRIPTION
Closes #156

This PR adds a `LogInitialisation` boolean option (defaulting to `true` to mirror current behavior) that allows the initial startup STDOUT to be suppressed. This is desirable when you want complete control of your program's STDOUT. It's also desirable when, for example, setting a `NetworkKey` with the Security API enabled and **NOT** wanting that key exposed in the STDOUT `Options Overrides` section.

I felt it more appropriate to add a new option that is specific to this node implementation rather than inferring from the [open-zwave official config options](https://github.com/OpenZWave/open-zwave/wiki/Config-Options) `Logging` and `ConsoleOutput` as you may want to just skip this init message but keep the other options enabled.

/cc @ekarak @Jovaage @DvStephen