### PR TITLE
Fix scene values type 'list' (Partially fix #266)

### DIFF
--- a/src/openzwave-scenes.cc
+++ b/src/openzwave-scenes.cc
@@ -137,7 +137,7 @@ namespace OZW {
 				}
 				case OpenZWave::ValueID::ValueType_Decimal: {
 					//float val; OpenZWave::Manager::Get()->GetValueAsFloat(*vit, &val);
-					float val = Nan::To<Number>(info[valoffset]).ToLocalChecked()->NumberValue();
+					float val = Nan::To<Number>(info[valoffset]).ToLocalChecked()->Value();
 					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
 					break;
 				}
@@ -150,7 +150,7 @@ namespace OZW {
 				case OpenZWave::ValueID::ValueType_List: {
 					//std::string val; OpenZWave::Manager::Get()->GetValueListSelection(*vit, &val);
 					std::string val(*Nan::Utf8String( info[valoffset] ));
-					OpenZWave::Manager::Get()->AddSceneValue(sceneid, *vit, val);
+					OpenZWave::Manager::Get()->AddSceneValueListSelection(sceneid, *vit, val);
 					break;
 				}
 				case OpenZWave::ValueID::ValueType_Short: {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -174,6 +174,17 @@ namespace OZW {
 				AddStringProp(valobj, value, val);
 				break;
 			}
+			case OpenZWave::ValueID::ValueType_List: {
+				std::string val;
+				std::vector < std::string > items;
+				// populate array of all available items in the list
+				OpenZWave::Manager::Get()->GetValueListItems(value, &items);
+				AddArrayOfStringProp(valobj, values, items);
+				// populated selected element
+				OpenZWave::Manager::Get()->SceneGetValueAsString(sceneid, value, &val);
+				AddStringProp(valobj, value, val.c_str())
+				break;
+			}
 			case OpenZWave::ValueID::ValueType_Int: {
 				int32 val;
 				OpenZWave::Manager::Get()->SceneGetValueAsInt(sceneid, value, &val);
@@ -197,7 +208,6 @@ namespace OZW {
 			*/
 			case OpenZWave::ValueID::ValueType_Button:
 			case OpenZWave::ValueID::ValueType_Schedule:
-			case OpenZWave::ValueID::ValueType_List:
 			case OpenZWave::ValueID::ValueType_Raw: {
 				fprintf(stderr, "unsupported scene value type: 0x%x\n", value.GetType());
 				break;


### PR DESCRIPTION
This is a partially fix of #266.

Please @ekarak check this commit. I have fixed list type values on scenes but there are still errors with 'decimal' types. The value is correctly stored in scene value (also in zwscene.xml) but when the scene is activate the value is not correctly parsed and it is set to default: 

The value in `zwscene.xml`
```xml
<Value homeId="0xe84dc80d" nodeId="3" genre="user" commandClassId="67" instance="1" index="1" type="decimal">30.500000</Value>
```

When I call activateScene: 
`zwave node 3: changed: 67:Heating:20.0 -> 5.0`

It is set to 5 that is the min value.

This is the returned object value from `getSceneValues`

```javascript
{ value_id: '3-67-1-1',
    node_id: 3,
    class_id: 67,
    type: 'decimal',
    genre: 'user',
    instance: 1,
    index: 1,
    label: 'Heating',
    units: 'C',
    help: '',
    read_only: false,
    write_only: false,
    min: 0,
    max: 0,
    is_polled: false,
    value: '30.500000' }
```
