### PR TITLE
Updated Raspbian Readme to fix bug when installing on Raspbian stretch

### DIFF
--- a/README-raspbian.md
+++ b/README-raspbian.md
@@ -42,6 +42,10 @@ make it permanent by adding it to /etc/environment
 ```
 sudo sed -i '$a LD_LIBRARY_PATH=/usr/local/lib' /etc/environment
 ```
+Refresh the dynamic libraries cache
+```
+sudo ldconfig -r
+```
 At this step you can ensure Open-Zwave library is correctly installed with
 ```
 MinOZW

--- a/README-raspbian.md
+++ b/README-raspbian.md
@@ -44,7 +44,7 @@ sudo sed -i '$a LD_LIBRARY_PATH=/usr/local/lib' /etc/environment
 ```
 Refresh the dynamic libraries cache
 ```
-sudo ldconfig -r
+sudo ldconfig
 ```
 At this step you can ensure Open-Zwave library is correctly installed with
 ```


### PR DESCRIPTION
Added command to docs to prevent error on Raspbian stretch: 

`Error: libopenzwave.so.1.4: cannot open shared object file: No such file or directory`