### PR TITLE
Added UpdateOptions api to update OpenZWave options

### DIFF
--- a/src/openzwave-driver.cc
+++ b/src/openzwave-driver.cc
@@ -66,10 +66,10 @@ namespace OZW {
 		CheckMinArgs(1, "info");
 
 		OZW* self = ObjectWrap::Unwrap<OZW>(info.This());
-		std::string ozw_userpath;
-		std::string ozw_config_path;
+		::std::string ozw_userpath;
+		::std::string ozw_config_path;
 
-		std::string option_overrides;
+		::std::string option_overrides;
 		bool log_initialisation = true;
 		// Options are global for all drivers and can only be set once.
 		if (info.Length() > 0) {
@@ -77,9 +77,9 @@ namespace OZW {
 			Local < Array > props = Nan::GetOwnPropertyNames(opts).ToLocalChecked();
 			for (unsigned int i = 0; i < props->Length(); ++i) {
 				Local<Value> key       = props->Get(i);
-				std::string  keyname   = *Nan::Utf8String(key);
+				::std::string  keyname   = *Nan::Utf8String(key);
 				Local<Value> argval    = Nan::Get(opts, key).ToLocalChecked();
-				std::string  argvalstr = *Nan::Utf8String(argval);
+				::std::string  argvalstr = *Nan::Utf8String(argval);
 				// UserPath is directly passed to Manager->Connect()
 				// scan for OpenZWave options.xml in the nodeJS module's '/config' subdirectory
 				if (keyname == "UserPath") {

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -241,7 +241,7 @@ namespace OZW {
 		self->log_initialisation = log_initialisation;
 
 		if (self->log_initialisation) {
-			std::ostringstream versionstream;
+			::std::ostringstream versionstream;
 
 			versionstream << ozw_vers_major << "." << ozw_vers_minor << "." << ozw_vers_revision;
 			::std::cout << "Initialising OpenZWave " << versionstream.str() << " binary addon for Node.JS.\n";

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -72,6 +72,7 @@ namespace OZW {
 		Nan::SetPrototypeMethod(t, "getSendQueueCount", OZW::GetSendQueueCount);	// ** new
 		Nan::SetPrototypeMethod(t, "connect", OZW::Connect);
 		Nan::SetPrototypeMethod(t, "disconnect", OZW::Disconnect);
+		Nan::SetPrototypeMethod(t, "updateOptions", OZW::UpdateOptions);
 		// openzwave-groups.cc
 		Nan::SetPrototypeMethod(t, "getNumGroups", OZW::GetNumGroups);
 		Nan::SetPrototypeMethod(t, "getAssociations", OZW::GetAssociations);
@@ -233,7 +234,13 @@ namespace OZW {
 			}
 		}
 
-		if (log_initialisation) {
+		// Store configuration data for connect.
+		self->config_path = ozw_config_path;
+		self->userpath = ozw_userpath;
+		self->option_overrides = option_overrides;
+		self->log_initialisation = log_initialisation;
+
+		if (self->log_initialisation) {
 			std::ostringstream versionstream;
 			versionstream << ozw_vers_major << "." << ozw_vers_minor << "." << ozw_vers_revision;
 			std::cout << "Initialising OpenZWave " << versionstream.str() << " binary addon for Node.JS.\n";
@@ -250,11 +257,6 @@ namespace OZW {
 				std::cout << "\tOption Overrides :" << option_overrides << "\n";
 			}
 		}
-
-		// Store configuration data for connect.
-		self->config_path = ozw_config_path;
-		self->userpath = ozw_userpath;
-		self->option_overrides = option_overrides;
 
 		ctx_obj = Nan::Persistent<Object>(info.This());
 		resource = new Nan::AsyncResource("openzwave.callback", info.This());

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -169,10 +169,10 @@ namespace OZW {
 		static NAN_METHOD(SceneGetValues);
 		static NAN_METHOD(ActivateScene);
 
-    // Passing configuration around
-    std::string userpath;
-    std::string option_overrides;
-    std::string config_path;
+		// Passing configuration around
+    ::std::string userpath;
+    ::std::string option_overrides;
+    ::std::string config_path;
     bool log_initialisation;
 	};
 

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -170,10 +170,10 @@ namespace OZW {
 		static NAN_METHOD(ActivateScene);
 
 		// Passing configuration around
-    ::std::string userpath;
-    ::std::string option_overrides;
-    ::std::string config_path;
-    bool log_initialisation;
+		::std::string userpath;
+		::std::string option_overrides;
+		::std::string config_path;
+		bool log_initialisation;
 	};
 
 	// our ZWave Home ID

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -67,6 +67,7 @@ namespace OZW {
 		static NAN_METHOD(GetSendQueueCount);
 		static NAN_METHOD(Connect);
 		static NAN_METHOD(Disconnect);
+		static NAN_METHOD(UpdateOptions);
 		// openzwave-groups.cc
 		static NAN_METHOD(GetNumGroups);
 		static NAN_METHOD(GetAssociations);
@@ -172,6 +173,7 @@ namespace OZW {
     std::string userpath;
     std::string option_overrides;
     std::string config_path;
+    bool log_initialisation;
 	};
 
 	// our ZWave Home ID

--- a/test4.js
+++ b/test4.js
@@ -40,7 +40,7 @@ var zwavedriverpaths = {
 }
 
 var zwp = zwavedriverpaths[os.platform()];
-console.log("connecting to %s",zwp);
+console.log("Connecting to %s",zwp);
 zwave.connect(zwp);
 process.on('SIGINT', do_disconnect);
 setTimeout(do_disconnect, 3000);

--- a/test4.js
+++ b/test4.js
@@ -1,0 +1,46 @@
+var OpenZWave = require('./lib/openzwave-shared.js');
+var os = require('os');
+
+var zwave = new OpenZWave({
+	ConsoleOutput: false,
+	Logging: false,
+	SaveConfiguration: false,
+	DriverMaxAttempts: 3,
+	PollInterval: 500,
+	SuppressValueRefresh: true,
+});
+
+function do_disconnect() {
+	console.log('\n\n== Driver Statistics: %j',
+		zwave.getDriverStatistics());
+
+	console.log('disconnecting...');
+	zwave.disconnect(zwp);
+
+	zwave.updateOptions({
+		ConsoleOutput: true,
+		Logging: true,
+		SaveConfiguration: false,
+		DriverMaxAttempts: 3,
+		PollInterval: 500,
+		SuppressValueRefresh: true,
+	});
+
+	zwave.connect(zwp);
+	setTimeout(function(){
+		zwave.disconnect(zwp);
+		process.exit();
+	}, 10000);
+}
+
+var zwavedriverpaths = {
+	"darwin": '/dev/cu.usbmodem1411',
+	"linux": '/dev/ttyACM0',
+	"windows": '\\\\.\\COM3'
+}
+
+var zwp = zwavedriverpaths[os.platform()];
+console.log("connecting to %s",zwp);
+zwave.connect(zwp);
+process.on('SIGINT', do_disconnect);
+setTimeout(do_disconnect, 3000);

--- a/test4.js
+++ b/test4.js
@@ -30,7 +30,7 @@ function do_disconnect() {
 	setTimeout(function(){
 		zwave.disconnect(zwp);
 		process.exit();
-	}, 10000);
+	}, 5000);
 }
 
 var zwavedriverpaths = {


### PR DESCRIPTION
This PR adds a new api `updateOptions(options)` where options is an object with options parameters like the one passed to `new OpenZwave(options)`. Allows to change options after init. 

Added also `test4.js` that tests this new feature.

Related to #275