### PR TITLE
GetAssociationsInstances

### DIFF
--- a/README-api.md
+++ b/README-api.md
@@ -105,6 +105,7 @@ zwave.getMaxAssociations(nodeid, group);
 zwave.addAssociation(nodeid, group, target_nodeid);
 zwave.removeAssociation(nodeid, group, target_nodeid);
 zwave.isGroupMultiInstance(nodeid, group);
+zwave.getAssociationsInstances(nodeid, group);
 ```
 
 Resetting the controller.  Calling `hardReset` will clear any associations, so use

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openzwave-shared",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Node.JS bindings for OpenZWave including management and security functions",
   "main": "./lib/openzwave-shared.js",
   "types": "./types/openzwave-shared.d.ts",

--- a/src/openzwave-groups.cc
+++ b/src/openzwave-groups.cc
@@ -74,6 +74,48 @@ namespace OZW {
 	 *
 	 */
 	// ===================================================================
+	NAN_METHOD(OZW::GetAssociationsInstances)
+	// ===================================================================
+	{
+		Nan::HandleScope scope;
+		CheckMinArgs(2, "nodeid, groupidx");
+		OpenZWave::InstanceAssociation* associations;
+		uint8 nodeid   = Nan::To<Number>(info[0]).ToLocalChecked()->Value();
+		uint8 groupidx = Nan::To<Number>(info[1]).ToLocalChecked()->Value();
+
+		uint32 numNodes = 0;
+		OZWManagerAssign(numNodes, GetAssociations,
+			homeid, nodeid,	groupidx, &associations
+		);
+
+		Local<Array> o_assocs = Nan::New<Array>(numNodes);
+
+		for (uint8 i = 0; i < numNodes; i++) {
+			Local <Object> info = Nan::New<Object>();
+			info->Set(
+				Nan::New<String>("instance").ToLocalChecked(),
+				Nan::New<Integer>(associations[i].m_instance)
+			);
+			info->Set(
+				Nan::New<String>("nodeid").ToLocalChecked(),
+				Nan::New<Integer>(associations[i].m_nodeId)
+			);
+
+			o_assocs->Set(Nan::New<Integer>(i), info);
+		}
+
+		if (numNodes > 0) {
+			// The caller is responsible for freeing the array memory with a call to delete [].
+			delete associations;
+		}
+
+		info.GetReturnValue().Set(o_assocs);
+	}
+
+	/*
+	 *
+	 */
+	// ===================================================================
 	NAN_METHOD(OZW::GetMaxAssociations)
 	// ===================================================================
 	{

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -83,6 +83,7 @@ namespace OZW {
 		Nan::SetPrototypeMethod(t, "removeAssociation", OZW::RemoveAssociation);
 #if OPENZWAVE_16
 		Nan::SetPrototypeMethod(t, "isMultiInstance", OZW::IsMultiInstance);
+        Nan::SetPrototypeMethod(t, "getAssociationsInstances", OZW::GetAssociationsInstances);
 #endif
 
 		// openzwave-management.cc

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -77,6 +77,7 @@ namespace OZW {
 		static NAN_METHOD(GetGroupLabel);
 		static NAN_METHOD(AddAssociation);
 		static NAN_METHOD(RemoveAssociation);
+        static NAN_METHOD(GetAssociationsInstances);
 #if OPENZWAVE_16
     static NAN_METHOD(IsMultiInstance);
 #endif

--- a/types/openzwave-shared.d.ts
+++ b/types/openzwave-shared.d.ts
@@ -134,6 +134,11 @@ declare module "openzwave-shared" {
 			label: string;
 		}
 
+		export interface InstanceAssociation {
+			nodeid: number;
+			instance: number;
+		}
+
 		export interface IConstructorParameters {
 			/**
 			 * This is the directory location where various files created by the library are stored. Examples include the zwcfg_.xml and LogFiles_
@@ -415,6 +420,8 @@ declare module "openzwave-shared" {
 			nodeId: number,
 			groupIdx: number,
 		): boolean;
+
+		getAssociationsInstances(nodeId: number, groupIdx: number): Array<InstanceAssociation>;
 
 		// Exposed by "openzwave-management.cc"
 


### PR DESCRIPTION
This addresses #348 
Allows to query the association to instance relation which can already be added and removed.
I have used the same naming as the python openzwave binding. I bumped the version as well.

@ekarak let me know if this can added