### PR TITLE
Changes to make the windows build compatible with Node 12.

### DIFF
--- a/lib/install-ozw.js
+++ b/lib/install-ozw.js
@@ -142,10 +142,10 @@ function build(gypArgs, cb) {
 
 function copyFiles() {
   fsextra.copySync(tempPath + '/ozw/open-zwave-master/config', installPath + '/config');
-  fsextra.copySync(tempPath + '/ozw/open-zwave-master/cpp/src',  installPath + '/include', { filter: (src, dest) => {
+  fsextra.copySync(tempPath + '/ozw/open-zwave-master/cpp/src',  installPath + '/include', { filter: function (src, dest) {
     var stat = fs.statSync(src);
     return (stat && stat.isDirectory()) || !src.match(/^.*\.(?!h)[^.]+$/);
-  } });
+  }});
   fsextra.copySync(tempPath + '/ozw/open-zwave-master/build/Release',  installPath + '/bin');
 }
 
@@ -220,7 +220,7 @@ module.exports = function(opts) {
     fs.createReadStream( tempPath + "/ozw.zip")
       .pipe(unzip.Extract({ path: tempPath + '/ozw' }))
       .on('close', function() {
-        var sources = readdirSyncRecursive(tempPath + '/ozw/open-zwave-master/cpp').map((f) => f.replace(tempPath + '/ozw/open-zwave-master/cpp/', ''));
+        var sources = readdirSyncRecursive(tempPath + '/ozw/open-zwave-master/cpp').map(function (f) { return f.replace(tempPath + '/ozw/open-zwave-master/cpp/', ''); });
 	
 		
         sources = sources.filter(function(f) {

--- a/lib/install-ozw.js
+++ b/lib/install-ozw.js
@@ -187,17 +187,17 @@ module.exports = function(opts) {
   
   fs.mkdirSync(tempPath);
   fs.writeFileSync(tempPath + '/package.json', 
-	  `{
-		  "name": "",
-		  "version": "",
-		  "description": "",
-		  "main": "",
-		  "dependencies": {},
-		  "devDependencies": {},
-		  "scripts": {},
-		  "author": "",
-		  "license": ""
-		}`
+	  '{ \r\n' + 
+		'  "name": "", \r\n' + 
+		'  "version": "", \r\n' + 
+		'  "description": "", \r\n' + 
+		'  "main": "", \r\n' + 
+		'  "dependencies": {}, \r\n' + 
+		'  "devDependencies": {}, \r\n' + 
+		'  "scripts": {}, \r\n' + 
+		'  "author": "", \r\n' + 
+		'  "license": "" \r\n' + 
+		'}'
 	);
 	
   process.chdir(tempPath);

--- a/lib/install-ozw.js
+++ b/lib/install-ozw.js
@@ -5,7 +5,7 @@
 var fs = require('fs');
 var ChildProcess = require('child_process');
 var path = require('path');
-var request, unzip, gyp, wrench; //these are dynamically required later on
+var request, unzip, gyp, fsextra; //these are dynamically required later on
 
 var originalPath = process.cwd();
 var tempPath = path.resolve(require('os').tmpdir() + '/ozwinstall-' + Math.random().toString(36).substring(7));
@@ -97,8 +97,8 @@ function init() {
   console.log('Temp Path:', tempPath);
   console.log('Install Path:', installPath);
   
-  wrench.rmdirSyncRecursive(installPath, true);
-  wrench.mkdirSyncRecursive(installPath);
+  fsextra.removeSync(installPath);
+  fsextra.mkdirsSync(installPath);
 }
 
 function download(url, dest, cb) {
@@ -141,14 +141,39 @@ function build(gypArgs, cb) {
 }
 
 function copyFiles() {
-  wrench.copyDirSyncRecursive(tempPath + '/ozw/open-zwave-master/config', installPath + '/config');
-  wrench.copyDirSyncRecursive(tempPath + '/ozw/open-zwave-master/cpp/src',  installPath + '/include', { filter: /^.*\.(?!h)[^.]+$/ });
-  wrench.copyDirSyncRecursive(tempPath + '/ozw/open-zwave-master/build/Release',  installPath + '/bin');
+  fsextra.copySync(tempPath + '/ozw/open-zwave-master/config', installPath + '/config');
+  fsextra.copySync(tempPath + '/ozw/open-zwave-master/cpp/src',  installPath + '/include', { filter: (src, dest) => {
+    var stat = fs.statSync(src);
+    return (stat && stat.isDirectory()) || !src.match(/^.*\.(?!h)[^.]+$/);
+  } });
+  fsextra.copySync(tempPath + '/ozw/open-zwave-master/build/Release',  installPath + '/bin');
 }
 
 function handleError(err) {
   throw err;
 }
+
+function readdirSyncRecursive (dir) {
+    var results = [];
+    var list = fs.readdirSync(dir);
+    list.forEach(function(file) {
+        file = dir + '/' + file;
+        var stat = fs.statSync(file);
+        if (stat && stat.isDirectory()) { 
+            /* Recurse into a subdirectory */
+            results = results.concat(readdirSyncRecursive(file));
+        } else { 
+            /* Is a file */
+            results.push(file);
+        }
+    });
+
+
+	return results;
+}
+
+
+
 
 module.exports = function(opts) {
   if (/^win/.test(process.platform)) {
@@ -161,15 +186,27 @@ module.exports = function(opts) {
   }
   
   fs.mkdirSync(tempPath);
-
+  fs.writeFileSync(tempPath + '/package.json', 
+	  `{
+		  "name": "",
+		  "version": "",
+		  "description": "",
+		  "main": "",
+		  "dependencies": {},
+		  "devDependencies": {},
+		  "scripts": {},
+		  "author": "",
+		  "license": ""
+		}`
+	);
+	
   process.chdir(tempPath);
   console.log('Installing dependencies to ' + tempPath);
-  ChildProcess.execSync('npm install request unzip node-gyp wrench');
+  ChildProcess.execSync('npm install request unzipper node-gyp fs-extra');
   request = require(tempPath + '/node_modules/request');
-  unzip = require(tempPath + '/node_modules/unzip');
+  unzip = require(tempPath + '/node_modules/unzipper');
   gyp = require(tempPath + '/node_modules/node-gyp')();
-  wrench = require(tempPath + '/node_modules/wrench');
-  
+  fsextra = require(tempPath + '/node_modules/fs-extra');
 
   
   gypOptions = opts.gyp || gypOptions;
@@ -183,7 +220,9 @@ module.exports = function(opts) {
     fs.createReadStream( tempPath + "/ozw.zip")
       .pipe(unzip.Extract({ path: tempPath + '/ozw' }))
       .on('close', function() {
-        var sources = wrench.readdirSyncRecursive(tempPath + '/ozw/open-zwave-master/cpp');
+        var sources = readdirSyncRecursive(tempPath + '/ozw/open-zwave-master/cpp').map((f) => f.replace(tempPath + '/ozw/open-zwave-master/cpp/', ''));
+	
+		
         sources = sources.filter(function(f) {
           return f.match(/^(src|tinyxml)/) && f.match(/\.(c|cpp)$/);
         }).map(function(f) {


### PR DESCRIPTION
I was not able to successfully use this library with Node 12 on windows, getting several build errors on the openzwave.lib compilation.  I slogged through it a bit today and found some current alternative tools to use and have tested that this works successfully for me and the openzwave.lib is still compatible with my current projects.

replaced wrench with fs-extra because it is long deprecated.
replaced unzip with unzipper because unzip was not compat.

rewrote some of the file system directory lookups to be compatible with the original intent but using fs-extra.. or a custom recursive folder list.
added the package.json file to the temp folder for compat.