### PR TITLE
Updating the .travis.yml file to include windows builds as well as th…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 
+os:
+    - linux
+    - windows
+    
 sudo: required
 
 addons:
@@ -10,19 +14,29 @@ addons:
       - libudev-dev
 
 before_install:
-  - wget https://github.com/OpenZWave/open-zwave/archive/master.zip
-  - unzip master.zip
-  - cd open-zwave-master
-  - sudo make install
-  - sudo ldconfig /usr/local/lib /usr/local/lib64
-  - npm install -g node-gyp
-  - cd ..
+  - |
+    if [ "$TRAVIS_OS_NAME" = "linux" ]
+    then 
+        wget https://github.com/OpenZWave/open-zwave/archive/master.zip
+        unzip master.zip
+        cd open-zwave-master
+        sudo make install
+        sudo ldconfig /usr/local/lib /usr/local/lib64
+        npm install -g node-gyp
+        cd ..
+    fi
 
 node_js:
-  - "0.12"
-  - "4"
-  - "6"
   - "8"
   - "10"
   - "11"
   - "12"
+  
+matrix:
+  include:
+    - os: linux
+      node_js: "0.12"
+    - os: linux
+      node_js: "4"
+    - os: linux
+      node_js: "6"


### PR DESCRIPTION
Updating the .travis.yml file to include windows builds as well as the linux builds.  Not sure if this negates the need for the Appveyor build, but it does test windows now in multiple versions of node_js.

I removed .12, 4 and 6 from the Windows builds because they are failing anyway, (not caused by this change), and they aren't needed by me.

All of these builds succeeded on my travis-ci test.

linux .12, 4, 6, 8, 10, 11, 12
windows 8, 10, 11, 12