### PR TITLE
Fix type misspelling of OpenZWave option

### DIFF
--- a/types/openzwave-shared.d.ts
+++ b/types/openzwave-shared.d.ts
@@ -225,7 +225,7 @@ declare module "openzwave-shared" {
 			/**
 			 * Should the above value be how long to wait between polling the network devices, or how often all devices should be polled
 			 */
-			IntervalBetweenPools: boolean;
+			IntervalBetweenPolls: boolean;
 			/**
 			 * After Processing a Group Changed Notification, should we update the Return Routes Map on affected devices
 			 */


### PR DESCRIPTION
This PR fixes the `IntervalBetweenPolls` OpenZWave option that was misspelled in the TypeScript types here as `IntervalBetweenPools`.

I confirmed the spelling of "IntervalBetweenPolls" with what's [currently on open-zwave's **master** branch](https://github.com/OpenZWave/open-zwave/blob/5d18bbfb21d8cdc61ee6baae6f478c963297dfc5/cpp/src/Options.cpp#L118).