### PR TITLE
Expose GetNodeClassInformation to get the version of a Command Class

### DIFF
--- a/src/openzwave-nodes.cc
+++ b/src/openzwave-nodes.cc
@@ -44,6 +44,22 @@ namespace OZW {
 		info.GetReturnValue().Set( o_neighbors );
 	}
 
+	/*
+	* Gets the Command Class Version for a node
+	*/
+	// ===================================================================
+	NAN_METHOD(OZW::GetNodeClassInformation)
+	// =================================================================
+	{
+		Nan::HandleScope scope;
+		CheckMinArgs(2, "nodeid, commClass");
+		uint8 nodeid = Nan::To<Integer>(info[0]).ToLocalChecked()->Value();
+		uint8 commClass  = Nan::To<Integer>(info[1]).ToLocalChecked()->Value();
+		uint8 commClassVersion = 0;
+		OZWManager( GetNodeClassInformation, homeid, nodeid, commClass, NULL, &commClassVersion);
+		info.GetReturnValue().Set(Nan::New<Integer>(commClassVersion));
+	}
+
 #ifdef OPENZWAVE16_DEPRECATED
 	// =================================================================
 	NAN_METHOD(OZW::SetNodeOn)

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -162,6 +162,7 @@ namespace OZW {
 		Nan::SetPrototypeMethod(t, "getNodeGeneric", OZW::GetNodeGeneric); // ** new
 		Nan::SetPrototypeMethod(t, "getNodeManufacturerId", OZW::GetNodeManufacturerId); // ** new
 		Nan::SetPrototypeMethod(t, "getNodeNeighbors", OZW::GetNodeNeighbors);
+		Nan::SetPrototypeMethod(t, "getNodeClassInformation", OZW::GetNodeClassInformation);
 		Nan::SetPrototypeMethod(t, "getNodeProductId", OZW::GetNodeProductId); // ** new
 		Nan::SetPrototypeMethod(t, "getNodeProductType", OZW::GetNodeProductType); // ** new
 		Nan::SetPrototypeMethod(t, "getNodeSecurity", OZW::GetNodeSecurity); // ** new

--- a/src/openzwave.hpp
+++ b/src/openzwave.hpp
@@ -168,6 +168,7 @@ namespace OZW {
 		static NAN_METHOD(GetNodeProductType);
 		static NAN_METHOD(GetNodeProductId);
 		static NAN_METHOD(GetNodeNeighbors);
+		static NAN_METHOD(GetNodeClassInformation);
 	#if OPENZWAVE_16
 		static NAN_METHOD(GetMetaData);
 		static NAN_METHOD(GetChangeLog);

--- a/types/openzwave-shared.d.ts
+++ b/types/openzwave-shared.d.ts
@@ -631,6 +631,11 @@ declare module "openzwave-shared" {
 		getNodeNeighbors(nodeId: number): Array<number>;
 
 		/**
+		 * Gets the Command Class Version for a node.
+		 */
+		getNodeClassInformation(nodeId: number, commClass: number): number;
+
+		/**
 		 * LEGACY MODE (using setNodeOn)
 		 * @deprecated
 		 */


### PR DESCRIPTION
Hi,

I don't know what is your process for contributions. Let me know if something is missing.

Following some evolutions of the ZWave protocol it might be usefull, from a consumer perspective, to know what is the current Command Class version supported by a node to handle situations such as the SwitchMultilevel in its 4th version and its new [Target Value](https://github.com/OpenZWave/open-zwave/wiki/OpenZWave-1.6-Release-Notes#switchmultilevel-commandclass) (see also [ZWave Application Command Class Specification §4.72](https://www.silabs.com/documents/login/miscellaneous/SDS13781-Z-Wave-Application-Command-Class-Specification.pdf)). Might also answer to #287 

I propose here to simply expose the Version, not the command class name itself (because it is something we already know based on its ID).